### PR TITLE
Handle missing json files in download_snaphot.sh

### DIFF
--- a/download_snaphot.sh
+++ b/download_snaphot.sh
@@ -11,22 +11,25 @@ function dl_snapshot {
 	wget -O "${LOCAL}.$1" "${REMOTE}.$1"
 
 	echo "wget -O \"${SNAPSHOT}.$1.json\" \"${REMOTE}.$1.json\""
-	wget -O "${SNAPSHOT}.$1.json" "${REMOTE}.$1.json"
+	if wget -O "${SNAPSHOT}.$1.json" "${REMOTE}.$1.json";
+	then
+		SHA256=(`shasum -a 256 "${LOCAL}.$1"`)
+		SHA256=${SHA256[0]}
+		echo "{" > "${LOCAL}.$1.json"
+		echo "\"sha256\":\"${SHA256}\"," >> "${LOCAL}.$1.json"
+		echo "\"file\":\"${LOCAL}.$1\"," >> "${LOCAL}.$1.json"
+		grep "commit" "${SNAPSHOT}.$1.json" >> "${LOCAL}.$1.json"
+		echo -n "}" >> "${LOCAL}.$1.json"
 
-	SHA256=(`shasum -a 256 "${LOCAL}.$1"`)
-	SHA256=${SHA256[0]}
-	echo "{" > "${LOCAL}.$1.json"
-	echo "\"sha256\":\"${SHA256}\"," >> "${LOCAL}.$1.json"
-	echo "\"file\":\"${LOCAL}.$1\"," >> "${LOCAL}.$1.json"
-	grep "commit" "${SNAPSHOT}.$1.json" >> "${LOCAL}.$1.json"
-	echo -n "}" >> "${LOCAL}.$1.json"
-
-	A=`grep sha256 "${SNAPSHOT}.$1.json"`
-	B=`grep sha256 "${LOCAL}.$1.json"`
-	echo "$A == $B"
-	if [ "$A" != "$B" ] ; then
-		echo "ERROR: Checksum failure for ${LOCAL}.$1.json"
-		exit 1
+		A=`grep sha256 "${SNAPSHOT}.$1.json"`
+		B=`grep sha256 "${LOCAL}.$1.json"`
+		echo "$A == $B"
+		if [ "$A" != "$B" ] ; then
+			echo "ERROR: Checksum failure for ${LOCAL}.$1.json"
+			exit 1
+		fi
+	else
+		echo "No json file for ${REMOTE}.$1"
 	fi
 }
 


### PR DESCRIPTION
For some reason, there's almost always a missing json file on bintray, so
change `download_snaphot.sh` (sic) so that it continues when that's the case.
It means that there's no check that the release file was correctly downloaded,
so will need to do that manually.