### PR TITLE
disable strict host checks in git

### DIFF
--- a/ci_boost_common.py
+++ b/ci_boost_common.py
@@ -567,6 +567,7 @@ class ci_appveyor(object):
         pass
 
 def main(script_klass):
+    os.environ['GIT_SSH_COMMAND'] = 'ssh -o StrictHostKeyChecking=no'
     if os.getenv('TRAVIS', False):
         script_klass(ci_travis)
     elif os.getenv('CIRCLECI', False):


### PR DESCRIPTION
This change solves the problem where the git server host/ssh signature has changed.
Previously the script could stall awaiting user input.
 
