### PR TITLE
Docker

### DIFF
--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:xenial
+LABEL maintainer="samuel.d.darwin@gmail.com"
+
+WORKDIR /root
+
+RUN apt-get update && apt-get install -y \
+        p7zip-full  \
+        curl \
+        docutils-common \
+        docutils-doc \
+        docbook \
+        docbook-xml \
+        docbook-xsl \
+        dvipsk-ja \
+        xsltproc \
+        openssh-client \
+        git \
+        graphviz \
+        texlive \
+        sshpass \
+        ghostscript \
+        unzip \
+        wget \
+        python-pip \
+        ruby \
+        python-docutils \
+        libsaxonhe-java \
+        cmake \
+        bison \
+        flex \
+        texlive-latex-extra \
+        default-jre-headless \
+    && git clone -b 'Release_1_8_15' --depth 1 https://github.com/doxygen/doxygen.git \
+    && cd doxygen \
+    && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release \
+    && cd build \
+    && make install \
+    && cd && rm -rf doxygen* \
+    && wget -O saxonhe.zip https://sourceforge.net/projects/saxon/files/Saxon-HE/9.9/SaxonHE9-9-1-4J.zip/download \
+    && unzip saxonhe.zip \
+    && rm /usr/share/java/Saxon-HE.jar \
+    && cp saxon9he.jar /usr/share/java/Saxon-HE.jar \
+    && rm -r * \
+    && mkdir build && cd build \
+    && wget -O rapidxml.zip http://sourceforge.net/projects/rapidxml/files/latest/download \
+    && unzip -n -d rapidxml rapidxml.zip \
+    && pip install --user docutils==0.12 \
+    && echo "Sphinx==1.5.6" > constraints.txt \
+    && pip install --user Sphinx==1.5.6 \
+    && pip install --user sphinx-boost==0.0.3 \
+    && pip install --user -c /root/build/constraints.txt git+https://github.com/rtfd/recommonmark@50be4978d7d91d0b8a69643c63450c8cd92d1212 \ 
+    && wget -O docbook-xml.zip http://www.docbook.org/xml/4.5/docbook-xml-4.5.zip \
+    && unzip -n -d docbook-xml docbook-xml.zip \
+    && wget -O docbook-xsl.zip https://sourceforge.net/projects/docbook/files/docbook-xsl/1.79.1/docbook-xsl-1.79.1.zip/download \
+    && unzip -n -d docbook-xsl docbook-xsl.zip \
+    && gem install asciidoctor --version 1.5.8 \
+    && asciidoctor --version \
+    && gem install pygments.rb --version 1.2.1 \
+    && pip install --user Pygments==2.1 \
+    && pip install --user https://github.com/bfgroup/jam_pygments/archive/master.zip \
+    && pip install --user future==0.18.2 \
+    && pip install --user six==1.15.0 \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean -y

--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y \
         flex \
         texlive-latex-extra \
         default-jre-headless \
+        python3 \
     && git clone -b 'Release_1_8_15' --depth 1 https://github.com/doxygen/doxygen.git \
     && cd doxygen \
     && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release \

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,0 +1,69 @@
+FROM ubuntu:bionic
+LABEL maintainer="samuel.d.darwin@gmail.com"
+
+WORKDIR /root
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata \
+    && apt-get install -y \
+        p7zip-full  \
+        curl \
+        docutils-common \
+        docutils-doc \
+        docbook \
+        docbook-xml \
+        docbook-xsl \
+        xsltproc \
+        openssh-client \
+        git \
+        graphviz \
+        texlive \
+        sshpass \
+        ghostscript \
+        unzip \
+        wget \
+        python3-pip \
+        ruby \
+        python3-docutils \
+        libsaxonhe-java \
+        cmake \
+        bison \
+        flex \
+        texlive-latex-extra \
+        default-jre-headless \
+    && git clone -b 'Release_1_8_15' --depth 1 https://github.com/doxygen/doxygen.git \
+    && cd doxygen \
+    && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release \
+    && cd build \
+    && make install \
+    && cd && rm -rf doxygen* \
+    && wget -O saxonhe.zip https://sourceforge.net/projects/saxon/files/Saxon-HE/9.9/SaxonHE9-9-1-4J.zip/download \
+    && unzip saxonhe.zip \
+    && rm /usr/share/java/Saxon-HE.jar \
+    && cp saxon9he.jar /usr/share/java/Saxon-HE.jar \
+    && rm -r * \
+    && mkdir build && cd build \
+    && wget -O rapidxml.zip http://sourceforge.net/projects/rapidxml/files/latest/download \
+    && unzip -n -d rapidxml rapidxml.zip \
+    && echo "Sphinx==1.5.6" > constraints.txt \
+    && pip3 install --user Sphinx==1.5.6 \
+    && pip3 install --user sphinx-boost==0.0.3 \
+    && pip3 install --user -c /root/build/constraints.txt git+https://github.com/rtfd/recommonmark@50be4978d7d91d0b8a69643c63450c8cd92d1212 \ 
+    && wget -O docbook-xml.zip http://www.docbook.org/xml/4.5/docbook-xml-4.5.zip \
+    && unzip -n -d docbook-xml docbook-xml.zip \
+    && wget -O docbook-xsl.zip https://sourceforge.net/projects/docbook/files/docbook-xsl/1.79.1/docbook-xsl-1.79.1.zip/download \
+    && unzip -n -d docbook-xsl docbook-xsl.zip \
+    && gem install asciidoctor --version 1.5.8 \
+    && asciidoctor --version \
+    && git clone -b python3 https://github.com/CPPAlliance/pygments.rb \
+    && cd pygments.rb \
+    && gem install multi_json --version 1.14.1 \
+    && ruby cache-lexers.rb \
+    && gem build pygments.rb.gemspec \
+    && gem install pygments.rb-1.2.2.gem \
+    && pip3 install --user Pygments==2.2.0 \
+    && pip3 install --user https://github.com/bfgroup/jam_pygments/archive/master.zip \
+    && pip3 install --user future==0.18.2 \
+    && pip3 install --user six==1.11.0 \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean -y


### PR DESCRIPTION
Includes the following Dockerfiles:

python2/Dockerfile - This is the current image for boost releases.  It's been updated with a small change, to install the python3 package, in case a library needs it.   However, still mainly using python2.

python3/Dockerfile - Major upgrade to use python3 for everything.  Almost ready.  Should be hosted on docker hub with a different tag (such as ":python3"), and will require all the other release-tools to support python3.
