### PR TITLE
github releases

### DIFF
--- a/ci_boost_common.py
+++ b/ci_boost_common.py
@@ -258,6 +258,7 @@ class script_common(object):
         self.bintray_key = os.getenv('BINTRAY_KEY')
         self.sf_releases_key = os.getenv('SF_RELEASES_KEY')
         self.gh_token = os.getenv('GH_TOKEN')
+        self.artifactory_pass = os.getenv('ARTIFACTORY_PASS')
 
         try:
             self.start()

--- a/ci_boost_common.py
+++ b/ci_boost_common.py
@@ -257,6 +257,7 @@ class script_common(object):
         # API keys.
         self.bintray_key = os.getenv('BINTRAY_KEY')
         self.sf_releases_key = os.getenv('SF_RELEASES_KEY')
+        self.gh_token = os.getenv('GH_TOKEN')
 
         try:
             self.start()

--- a/ci_boost_release.py
+++ b/ci_boost_release.py
@@ -11,6 +11,7 @@ import time
 import shutil
 import site
 import hashlib
+import subprocess
 
 from ci_boost_common import main, utils, script_common, parallel_call
 
@@ -280,7 +281,27 @@ class script(script_common):
         utils.check_call('ls','-la')
     
     def upload_archives(self, *filenames):
-        if not self.sf_releases_key and not self.bintray_key:
+
+        self.bintray_user="boostsys"
+        self.bintray_org="boostorg"
+
+	# If GH_TOKEN is set, github releases will activate, similar to the logic for BINTRAY_KEY.
+	# The variable "github_releases_main_repo" determines if github releases will be hosted on the boost repository itself.
+	# If set to False, the github releases will be directed to a separate repo.
+        github_releases_main_repo=False
+
+        # The next two variables are only used if github_releases_main_repo==False
+        github_releases_target_org="boostorg"
+        github_releases_target_repo="boost-releases"
+
+        if github_releases_main_repo:
+            github_releases_folder=self.root_dir
+        else:
+            github_releases_folder=os.path.join(os.path.dirname(self.root_dir),"ghreleases")
+
+        github_release_name=self.branch + "-snapshot"
+
+        if not self.sf_releases_key and not self.bintray_key and not self.gh_token:
             utils.log( "ci_boost_release: upload_archives: no sf_releases_key and no bintray_key" )
             return
         curl_cfg_data = []
@@ -291,7 +312,7 @@ class script(script_common):
                 ]
         if self.bintray_key:
             curl_cfg_data += [
-                'user = "%s:%s"'%('boostsys',self.bintray_key),
+                'user = "%s:%s"'%(self.bintray_user,self.bintray_key),
                 ]
         utils.make_file(curl_cfg,*curl_cfg_data)
         # Create version ahead of uploading to avoid invalid version errors.
@@ -302,7 +323,7 @@ class script(script_common):
             utils.check_call('curl',
                 '-K',curl_cfg,
                 '-T',os.path.join(self.build_dir,'bintray_release.json'),
-                'https://api.bintray.com/packages/boostorg/%s/snapshot/versions'%(
+                'https://api.bintray.com/packages/' + self.bintray_org + '/%s/snapshot/versions'%(
                     # repo
                     self.branch))
         # Setup before we can upload to the release services.
@@ -316,18 +337,91 @@ class script(script_common):
                 utils.check_call('curl',
                     '-K',curl_cfg,
                     '-X','DELETE',
-                    'https://api.bintray.com/content/boostorg/%s/%s'%(
+                    'https://api.bintray.com/content/' + self.bintray_org + '/%s/%s'%(
                         # repo, file
                         self.branch,filename))
                 utils.check_call('curl',
                     '-K',curl_cfg,
                     '-X','DELETE',
-                    'https://api.bintray.com/content/boostorg/%s/%s.asc'%(
+                    'https://api.bintray.com/content/' + self.bintray_org + '/%s/%s.asc'%(
                         # repo, file
                         self.branch,filename))
 
         # # The uploads to the release services happen in parallel to minimize clock time.
         # uploads = []
+
+        # Prepare gh uploads
+        if self.gh_token:
+            os.chdir(os.path.dirname(self.root_dir))
+
+            # Check out github releases target repo, if necessary
+            if not github_releases_main_repo:
+                if os.path.isdir(github_releases_folder):
+                    os.chdir(github_releases_folder)
+                    utils.check_call('git',
+                        'pull',
+                        'https://github.com/%s/%s'%(github_releases_target_org,github_releases_target_repo))
+                    utils.check_call('git',
+                        'checkout',
+                        '%s'%(self.branch))
+                else:
+                    utils.check_call('git',
+                        'clone',
+                        'https://github.com/%s/%s'%(github_releases_target_org,github_releases_target_repo),
+                        '%s'%(github_releases_folder)
+                        )
+                    os.chdir(github_releases_folder)
+                    utils.check_call('git',
+                        'checkout',
+                        '%s'%(self.branch))
+
+            os.chdir(github_releases_folder)
+
+            # gh has a concept called "base" repo. Pointing it to "origin".
+            utils.check_call('git',
+                    'config',
+                    '--local',
+                    'remote.origin.gh-resolved',
+                    'base')
+
+            # allow credentials to be read from $GH_USER and $GH_TOKEN env variables
+            credentialhelperscript='!f() { sleep 1; echo "username=${GH_USER}"; echo "password=${GH_TOKEN}"; }; f'
+            utils.check_call('git',
+                    'config',
+                    'credential.helper',
+                    '%s'%(credentialhelperscript))
+
+            # Create a release, if one is not present
+            list_of_releases=subprocess.check_output(['gh',
+                'release',
+                'list'])
+
+            if github_release_name not in list_of_releases:
+                utils.check_call('gh',
+                    'release',
+                    'create',
+                    '%s'%(github_release_name),
+                    '-t',
+                    '%s snapshot'%(self.branch),
+                    '-n',
+                    'Latest snapshot of %s branch'%(self.branch))
+
+            # Update the tag
+            # When github_releases_main_repo is False, this may not be too important.
+            # If github_releases_main_repo is True, the git tag should match the release.
+            os.chdir(github_releases_folder)
+            utils.check_call('git',
+                    'tag',
+                    '-f',
+                    '%s'%(github_release_name))
+            utils.check_call('git',
+                    'push',
+                    '-f',
+                    'origin',
+                    '%s'%(github_release_name))
+
+            # Finished with "prepare gh uploads". Set directory back to reasonable value.
+            os.chdir(os.path.dirname(self.root_dir))
 
         for filename in filenames:
             if self.sf_releases_key:
@@ -346,9 +440,18 @@ class script(script_common):
                 utils.check_call('curl',
                     '-K',curl_cfg,
                     '-T',filename,
-                    'https://api.bintray.com/content/boostorg/%s/snapshot/%s/%s?publish=1&override=1'%(
+                    'https://api.bintray.com/content/' + self.bintray_org + '/%s/snapshot/%s/%s?publish=1&override=1'%(
                         # repo, version, file
                         self.branch,self.commit,filename))
+            if self.gh_token:
+                os.chdir(github_releases_folder)
+                utils.check_call('gh',
+                    'release',
+                    'upload',
+                    '%s'%(github_release_name),
+                    '%s'%(os.path.join(os.path.dirname(self.root_dir),filename)),
+                    '--clobber')
+                os.chdir(os.path.dirname(self.root_dir))
 
         # for upload in uploads:
         #     upload.join()

--- a/ci_boost_release.py
+++ b/ci_boost_release.py
@@ -288,7 +288,7 @@ class script(script_common):
 	# If GH_TOKEN is set, github releases will activate, similar to the logic for BINTRAY_KEY.
 	# The variable "github_releases_main_repo" determines if github releases will be hosted on the boost repository itself.
 	# If set to False, the github releases will be directed to a separate repo.
-        github_releases_main_repo=False
+        github_releases_main_repo=True
 
         # The next two variables are only used if github_releases_main_repo==False
         github_releases_target_org="boostorg"

--- a/github_releases.py
+++ b/github_releases.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+
+# Copyright Sam Darwin 2021
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+
+# Upload new official releases to github.
+# The functionality should be merged with any existing official releases scripts.
+#
+# Use ci_boost_release.py instead for development snapshots.
+#
+# INSTRUCTIONS:
+#
+# Set values in Config section below.
+#
+# Set the following environment vars:
+# GH_USER: name of account on github
+# GH_TOKEN: auth token for github
+#
+# The directory structure will be as follows:
+#
+# ls -al
+# .
+# ..
+# ghreleases/
+# project/
+# github_releases.py
+# boost_1_76_0.tar.gz
+# boost_1_76_0.tar.gz.json
+# boost_1_76_0.tar.bz2
+# boost_1_76_0.tar.gz.json
+# boost_1_76_0.zip
+# boost_1_76_0.zip.json
+# boost_1_76_0.7z
+# boost_1_76_0.7z.json
+#
+# The script assumes the release files such as boost_1_76_0.tar.gz have already been generated
+# and are available in the current working directory.
+# If publishing releases to boostorg/boost, the project/ directory should be a checked out copy of that repository.
+# If publishing releases to boostorg/boost-releases, the ghreleases/ directory will be used to check out that repo.
+
+import sys
+import os
+import subprocess
+from ci_boost_common import utils
+
+# Config
+
+github_release_name="boost-1.76.0"
+github_release_title="Boost 1.76.0"
+github_release_notes="description here"
+boost_package_name="boost_1_76_0-snapshot"
+
+# The variable "github_releases_main_repo" determines if github releases will be hosted on the boost repository itself.
+# It is assumed the main repo has been very recently checked out, and is located in github_releases_main_repo_local_directory.
+github_releases_main_repo=False
+github_releases_main_repo_local_directory="project"
+
+# The next two variables are only used if github_releases_main_repo==False
+github_releases_target_org="boostorg"
+github_releases_target_repo="boost-releases"
+
+# Running the script from the "basedir", where the packages are.
+basedir = os.getcwd()
+
+file_extensions=[".tar.gz",".tar.gz.json",".tar.bz2",".tar.bz2.json",".zip",".zip.json",".7z",".7z.json"]
+filenames=[ boost_package_name+name for name in file_extensions ]
+
+if github_releases_main_repo:
+    github_releases_folder=os.path.join(basedir, github_releases_main_repo_local_directory)
+else:
+    github_releases_folder=os.path.join(basedir, "ghreleases")
+
+gh_token = os.getenv('GH_TOKEN')
+gh_user = os.getenv('GH_USER')
+
+if not gh_token or not gh_user:
+   print("Please set the environment variables GH_TOKEN and GH_USER.")
+   sys.exit()
+
+# Check out github releases target repo, if necessary
+if not github_releases_main_repo:
+    if os.path.isdir(github_releases_folder):
+        os.chdir(github_releases_folder)
+        utils.check_call('git', 'pull', 'https://github.com/%s/%s'%(github_releases_target_org, github_releases_target_repo))
+        utils.check_call('git', 'checkout', 'master')
+    else:
+        utils.check_call('git',
+            'clone', 'https://github.com/%s/%s'%(github_releases_target_org, github_releases_target_repo),
+            '%s'%(github_releases_folder)
+            )
+        os.chdir(github_releases_folder)
+        utils.check_call('git', 'pull', 'https://github.com/%s/%s'%(github_releases_target_org, github_releases_target_repo))
+        utils.check_call('git', 'checkout', 'master')
+elif github_releases_main_repo:
+        os.chdir(github_releases_folder)
+        # Error checking
+        checkbranch=subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).strip()
+        if checkbranch not in "master":
+           print("An official release is usually done from the master branch. However, the branch is " + checkbranch)
+           print("Please review this. Exiting.")
+           sys.exit()
+
+# gh has a concept called "base" repo. Pointing it to "origin".
+utils.check_call('git', 'config', '--local', 'remote.origin.gh-resolved', 'base')
+
+# allow git credentials to be read from $GH_USER and $GH_TOKEN env variables
+credentialhelperscript='!f() { sleep 1; echo "username=${GH_USER}"; echo "password=${GH_TOKEN}"; }; f'
+utils.check_call('git', 'config', 'credential.helper', '%s'%(credentialhelperscript))
+
+# Create a release, if one is not present
+list_of_releases=subprocess.check_output(['gh', 'release', 'list'])
+
+if github_release_name not in list_of_releases:
+    utils.check_call('gh',
+                    'release',
+                    'create',
+                    '%s'%(github_release_name),
+                    '-t',
+                    '%s'%(github_release_title),
+                    '-n',
+                    '%s'%(github_release_notes))
+
+# Update the tag
+# When github_releases_main_repo is False, this may not be too important.
+# If github_releases_main_repo is True, the git tag should match the release.
+os.chdir(github_releases_folder)
+utils.check_call('git',
+        'tag',
+        '-f',
+        '%s'%(github_release_name))
+utils.check_call('git',
+        'push',
+        '-f',
+        'origin',
+        '%s'%(github_release_name))
+
+# upload the boost releases
+for filename in filenames:
+    utils.check_call('gh',
+        'release',
+        'upload',
+        '%s'%(github_release_name),
+        '%s'%(os.path.join(basedir,filename)),
+        '--clobber')

--- a/github_releases_import.py
+++ b/github_releases_import.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+# Copyright Sam Darwin 2021
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+# One-time upload of historical releases to github.
+#
+# INSTRUCTIONS:
+#
+# Download the releases from dl.bintray.com
+# wget -e robots=off  --recursive --page-requisites --adjust-extension --span-hosts --convert-links --domains dl.bintray.com --no-parent dl.bintray.com/boostorg/
+#
+# Set values in Config section below.
+# - The location of a local updated copy of the boost repository, such as github_releases_folder="/opt/github/project"
+# - The location of wherever the wget has downloaded the archives such as github_releases_local_archives="/drive2/boostorg"
+#   Within this dir are the subdirectories "beta, develop, master, release"
+#
+# Set the following environment vars:
+# GH_USER: name of account on github
+# GH_TOKEN: auth token for github
+
+import sys
+import os
+import subprocess
+import glob
+import re
+from ci_boost_common import utils
+
+# Config
+
+boost_versions=[ "1.63.0", "1.64.0", "1.65.0", "1.65.1", "1.66.0", "1.67.0", "1.68.0", "1.69.0", "1.70.0", "1.71.0", "1.72.0", "1.73.0", "1.74.0", "1.75.0" ]
+
+# Or for testing:
+# boost_versions=[ "1.74.0", "1.75.0" ]
+
+# Full path to local copy of boost repo
+github_releases_folder="/opt/github/project"
+os.chdir(github_releases_folder)
+
+# Full path to local mirror of bintray. Within this dir are "beta, develop, master, release"
+github_releases_local_archives="/drive2/boostorg"
+
+gh_token = os.getenv('GH_TOKEN')
+gh_user = os.getenv('GH_USER')
+
+if not gh_token or not gh_user:
+   print("Please set the environment variables GH_TOKEN and GH_USER.")
+   sys.exit()
+
+# gh has a concept called "base" repo. Pointing it to "origin".
+utils.check_call('git', 'config', '--local', 'remote.origin.gh-resolved', 'base')
+
+# allow git credentials to be read from $GH_USER and $GH_TOKEN env variables
+credentialhelperscript='!f() { sleep 1; echo "username=${GH_USER}"; echo "password=${GH_TOKEN}"; }; f'
+utils.check_call('git', 'config', 'credential.helper', '%s'%(credentialhelperscript))
+
+# Create a release, if one is not present
+list_of_releases=subprocess.check_output(['gh', 'release', 'list'])
+
+for version in boost_versions:
+    github_release_name="boost-" + version
+    github_release_title="Boost " + version
+    github_release_notes="Boost release"
+
+    if github_release_name not in list_of_releases:
+        utils.check_call('gh',
+                        'release',
+                        'create',
+                        '%s'%(github_release_name),
+                        '-t',
+                        '%s'%(github_release_title),
+                        '-n',
+                        '%s'%(github_release_notes))
+
+    for subfolder in ["source", "binaries"]:
+        file_location=github_releases_local_archives + "/release/" + version + "/" + subfolder + "/*"
+        list_of_files=glob.glob(file_location)
+        list_of_files.sort()
+        # print("List of files is ")
+        # print(list_of_files)
+        # exit()
+
+        # upload files
+        for filename in list_of_files:
+            if not re.search(".*(html)$", filename, flags=0):
+                utils.check_call('gh',
+                    'release',
+                    'upload',
+                    '%s'%(github_release_name),
+                    '%s'%(os.path.join(file_location,filename)),
+                    '--clobber')


### PR DESCRIPTION
Implements github releases using the [gh](https://github.com/cli/cli) tool, which is the official supported github cli. 
- When creating releases locally/manually, install gh. Instructions: https://github.com/cli/cli#installation
- For the CI scripts, add gh to the Docker container. The Docker images have been updated in this pull request https://github.com/boostorg/release-tools/pull/18

There are two alternatives when publishing boost github releases.
1. Add them to https://github.com/boostorg/boost
2. Create a separate repo for releases such as https://github.com/boostorg/boost-releases

The advantage of the first method is that it's expected to find the binaries in the same place as the source. Simple and convenient.
The advantage of the second method is that it's more secure. Access tokens for the main github repository would not be in CircleCI, where there's a small chance they could get hacked.
Either choice is possible with the scripts. 
Set github_releases_main_repo=True to use https://github.com/boostorg/boost
Set github_releases_main_repo=False to use another repo. Make sure to create the new repository.

Dev snapshots are published with ci_boost_release.py

Versioned releases are published in conjunction with github_releases.py. Let me know if github_releases.py needs to be modified or integrated with other scripts.

Add environment variables in CircleCI:

GH_USER: user account
GH_TOKEN: authentication token

Here is how it could be feasible to proceed with using the main repo: There's a feature in github called "Branch protection rules", in Settings->Branches. Turn this on for "master" and "develop" to prevent forced pushes and branch deletions. Maybe these steps have already been done. Create a new token for CircleCI that has standard access but not admin access.  
