### PR TITLE
Add "created" field to metadata

### DIFF
--- a/MakeBoostDistro.py
+++ b/MakeBoostDistro.py
@@ -16,6 +16,7 @@ import os, sys
 import shutil
 import stat
 import six
+import datetime
 
 IgnoreFiles = shutil.ignore_patterns(
 	'[.]*',
@@ -147,6 +148,11 @@ print("Dest   = %s" % DestRoot)
 if not os.path.exists(SourceRoot):
 	print("## Error: %s does not exist" % SourceRoot)
 	exit(1)
+
+if os.path.exists(DestRoot):
+    print("The destination directory already exists. Renaming it, so that a new one can be generated.\n")
+    timestamp1 = datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+    os.rename(DestRoot,DestRoot + "_bck_" + timestamp1)
 
 if not os.path.exists(DestRoot):
 	print("Creating destination directory %s" % DestRoot)

--- a/ci_boost_release.py
+++ b/ci_boost_release.py
@@ -476,12 +476,20 @@ class script(script_common):
         # Create archive info data files.
         for archive_file in archive_files:
             sha256_sum = hashlib.sha256(open(archive_file,"rb").read()).hexdigest()
+            created_date = ""
+            try:
+                created_date = subprocess.check_output("set -e && set -o pipefail; TZ=UTC git -C " + self.root_dir + " show -s --date='format-local:%Y-%m-%dT%H:%M:%SZ' " + self.commit + " | grep Date: | tr -s ' ' | cut -d' ' -f 2 ", universal_newlines=True, shell=True, executable='/bin/bash');
+                created_date = created_date.strip()
+            except:
+                print("Could not find the commit in the git log.")
+
             utils.make_file("%s.json"%(archive_file),
                 "{",
                 '"sha256":"%s",'%(sha256_sum),
                 '"file":"%s",'%(archive_file),
                 '"branch":"%s",'%(self.branch),
-                '"commit":"%s"'%(self.commit),
+                '"commit":"%s",'%(self.commit),
+                '"created":"%s"'%(created_date),
                 "}")
         
         # List the results for debugging.


### PR DESCRIPTION
The boost-tasks repo from Daniel James included a script release-from-bintray which was used to deploy an archive from bintray to the website. Changing from bintray to artifactory, the "created" timestamp metadata field was used by the earlier script, and should be provided.   To solve that, adding a "created" field to the archive's json file, which is a logical place to store the information, alongside the sha hash and commit.

Another small update also: when running ci_boost_release.py multiple times during testing, the program will crash if the destination folder is present. Let's rename the previous folder to ".bck", and continue to create a new bundle, without crashing. 
