### PR TITLE
Remove bintray

### DIFF
--- a/ci_boost_common.py
+++ b/ci_boost_common.py
@@ -271,7 +271,6 @@ class script_common(object):
             self.boost_version = 'default'
         
         # API keys.
-        self.bintray_key = os.getenv('BINTRAY_KEY')
         self.sf_releases_key = os.getenv('SF_RELEASES_KEY')
         self.gh_token = os.getenv('GH_TOKEN')
         self.artifactory_pass = os.getenv('ARTIFACTORY_PASS')


### PR DESCRIPTION
The bintray service was discontinued. It's no longer available.   
Remove bintray from release-tools files.