### PR TITLE
Scripts to build docs for specific boost libraries

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,289 @@
+---
+# Copyright 2022 Sam Darwin
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
+name: build_docs
+
+on:
+  pull_request:
+    paths:
+      - 'build_docs/**'
+  push:
+    paths:
+      - 'build_docs/**'
+    branches:
+      - master
+      - develop
+      - feature/**
+
+jobs:
+  linux:
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            container: ubuntu:22.04
+            packages: python2
+            skiplist: auto_index hof leaf qvm static_string
+          - os: ubuntu-latest
+            container: ubuntu:20.04
+            packages: python
+            skiplist: auto_index leaf qvm static_string
+          - os: ubuntu-latest
+            container: ubuntu:18.04
+            packages: python
+            skiplist: auto_index leaf qvm static_string
+          - os: ubuntu-latest
+            container: ubuntu:22.04
+            packages: python2
+            skiplist: auto_index hof static_string
+            flags: "--boostrelease"
+          - os: ubuntu-latest
+            container: ubuntu:20.04
+            packages: python
+            skiplist: auto_index static_string
+            flags: "--boostrelease"
+          - os: ubuntu-latest
+            container: ubuntu:18.04
+            packages: python
+            skiplist: auto_index static_string
+            flags: "--boostrelease"
+
+
+    timeout-minutes: 720
+    runs-on: ${{matrix.os}}
+    container: ${{matrix.container}}
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: docs
+        run: |
+            set -ex
+            apt-get update
+            DEBIAN_FRONTEND="noninteractive" apt-get install -y tzdata
+            apt-get install -y git sudo
+            apt-get install -y ${{ matrix.packages }}
+            if [ ! -f /usr/bin/python ]; then
+                ln -s /usr/bin/python2 /usr/bin/python
+            fi
+
+            cp build_docs/linuxdocs.sh /usr/local/bin/
+
+            mkdir -p /opt/github/boostorg
+            cd /opt/github/boostorg
+            git clone -b "develop" --depth 1 "https://github.com/boostorg/boost.git"
+            cd boost
+            git submodule update --init
+
+            # Run at least one full build that installs everything
+            cd libs/system
+            linuxdocs.sh ${{ matrix.flags }}
+            cd ../..
+
+            textpart1='#!/bin/bash
+            reponame=$1
+            echo "reponame is $reponame"
+            skiplist="'
+
+            textpart2="${{ matrix.skiplist }}"
+
+            textpart3='"
+            # jump ahead to continue testing
+
+            # if [[ "$reponame" =~ ^[a-fh-z] ]]; then
+            if [[ "$reponame" =~ ^[9] ]]; then
+               echo "skipping ahead X letters"
+            elif [[ "$skiplist" =~ $reponame ]]; then
+                echo "repo in skiplist"
+            else
+                linuxdocs.sh --quick '
+
+            textpart4=${{ matrix.flags }}
+            textpart5='
+            fi
+            '
+
+            textsource="${textpart1}${textpart2}${textpart3}${textpart4}${textpart5}"
+            echo "$textsource" > /usr/local/bin/runlinuxdocsquick
+            chmod 755 /usr/local/bin/runlinuxdocsquick
+            echo "checking runlinuxdocsquick"
+            cat /usr/local/bin/runlinuxdocsquick
+
+            git submodule foreach 'runlinuxdocsquick $name'
+
+  macos:
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            # why is boostorg/test failing
+            skiplist: auto_index hof leaf qvm static_string
+          - os: macos-latest
+            skiplist: auto_index hof static_string
+            flags: "--boostrelease"
+
+    timeout-minutes: 720
+    runs-on: ${{matrix.os}}
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: docs
+        run: |
+            set -e
+            cp build_docs/macosdocs.sh /usr/local/bin/
+
+            mkdir -p github/boostorg
+            cd github/boostorg
+            git clone -b "develop" --depth 1 "https://github.com/boostorg/boost.git"
+            cd boost
+            git submodule update --init
+
+            # Run at least one full build that installs everything
+            cd libs/system
+            macosdocs.sh
+            cd ../..
+
+            textpart1='#!/bin/bash
+            reponame=$1
+            echo "reponame is $reponame"
+            skiplist="'
+
+            textpart2="${{ matrix.skiplist }}"
+
+            textpart3='"
+            # jump ahead to continue testing
+
+            # if [[ "$reponame" =~ ^[a-s] ]]; then
+            if [[ "$reponame" =~ ^[9] ]]; then
+               echo "skipping ahead X letters"
+            elif [[ "$skiplist" =~ $reponame ]]; then
+                echo "repo in skiplist"
+            else
+                macosdocs.sh --quick '
+
+            textpart4=${{ matrix.flags }}
+
+            textpart5='
+            fi
+            '
+
+            textsource="${textpart1}${textpart2}${textpart3}${textpart4}${textpart5}"
+            echo "$textsource" > /usr/local/bin/runmacosdocsquick
+            chmod 755 /usr/local/bin/runmacosdocsquick
+            echo "check runmacosdocsquick"
+            cat /usr/local/bin/runmacosdocsquick
+
+            git submodule foreach 'runmacosdocsquick $name'
+
+  windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-2019
+            skiplist: auto_index hana hof log parameter parameter_python static_string leaf qvm
+          - os: windows-2022
+            skiplist: auto_index hana hof log parameter parameter_python static_string leaf qvm
+          - os: windows-2019
+            flags: "-boostrelease"
+            skiplist: auto_index hana hof log parameter parameter_python static_string
+          - os: windows-2022
+            flags: "-boostrelease"
+            skiplist: auto_index hana hof log parameter parameter_python static_string
+
+    timeout-minutes: 720
+    runs-on: ${{matrix.os}}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: docs
+        shell: powershell
+        run: |
+
+            function Runwindowsdocs {
+                pwd
+                windowsdocs.ps1
+                if ( ! $LASTEXITCODE -eq 0)  {
+                    echo 'doc build failed in github actions. exiting.'
+                    exit 1
+                }
+            }
+
+            # 'git submodule foreach' isn't seeing declared functions.
+            # As a workaround, place the function in a module. Load the module at runtime.
+
+            New-Item -ItemType Directory -Force -Path C:\scripts
+
+            $textpart1=@'
+            param( [String]$reponame)
+            pwd
+            echo "reponame is $reponame"
+            # need to research all skipped libraries.
+            $skiplist="
+            '@
+
+            $textpart2="${{ matrix.skiplist }}"
+
+            $textpart3=@'
+            "
+
+            # if ( $reponame -match '^[a-o]' ) {
+            if ( $reponame -match '^[9]' ) {
+                echo "skipping ahead X letters"
+                }
+            elseif ($skiplist -like "*$reponame*") {
+                echo "repo in skiplist"
+                }
+            else {
+                windowsdocs.ps1 -quick 
+            '@
+
+            $textpart4="${{ matrix.flags }}"
+
+            $textpart5=@'
+
+                if ( ! $LASTEXITCODE -eq 0)  {
+                    echo "doc build failed in github actions. exiting."
+                    exit 1
+                }
+            }
+            '@
+
+            $textsource="${textpart1}${textpart2}${textpart3}${textpart4}${textpart5}"
+            $textsource | Out-File c:\scripts\cifunctions.ps1
+
+            echo "Checking cifunctions.ps1"
+            cat c:\scripts\cifunctions.ps1
+
+            cp build_docs/windowsdocs.ps1 C:\windows\system32
+            echo "job"
+            mkdir C:\boostorg
+            cd C:\boostorg
+            git clone -b develop --depth 1 https://github.com/boostorg/boost.git boost
+            cd boost
+            git submodule update --init
+
+            # Run at least one full build that installs everything
+            cd libs/system
+            Runwindowsdocs
+            cd ../..
+
+            # For the rest --quick
+            git submodule foreach 'powershell -command C:/scripts/cifunctions.ps1 $name'

--- a/build_docs/README.md
+++ b/build_docs/README.md
@@ -1,0 +1,68 @@
+## Building the documentation for specific boost libraries
+
+Each boost libraries contains documentation in the doc/ folder. For example, https://github.com/boostorg/core has documentation in core/doc/. The format is generally [quickbook](https://www.boost.org/doc/libs/master/doc/html/quickbook.html) and needs to be compiled into html. The scripts here accomplish that.
+
+There are different possible configurations when building the docs:
+
+Option 1. Start out with one boost library, and nothing else.
+
+A new boost-root directory will be generated for you, next to the current repo, (in the location ../boost-root)  and the docs will be output to ../boost-root/libs/_name-of-this-repo_/doc/html
+
+or
+
+Option 2. You have already set up boost-root.
+
+The repo has already been placed in boost-root/libs/_name-of-this-repo_, and that's where you will run the build. In that case, the docs will be output in the current directory, such as _name-of-this-repo_/doc/html.  The existing boost-root will be used.
+
+Either of the above choices are possible. The build scripts detect if they are being run from a boost-root or not.
+
+In order to build the documentation, refer to the appropriate sections below.
+
+One of the main actions of these scripts is to install _packages_. Depending on the operating system this may be using apt, brew, choco, pip, or a different package manager. Usually this is perfectly fine. However, If you are concerned about package conflicts on your local machine, run the installation in a docker container or a separate cloud server to isolate the build process. The script will not install a C++ compiler, since there are many choices in that realm, so make sure a compiler is available.
+
+## Linux
+
+There various ways to run the script. One method is to run the script from the current location, and tell it where the docs are:
+```
+./linuxdocs.sh _path_to_boost_library_
+```
+Another method which might be easier is to copy the script into location in $PATH, so it can be run anywhere. Then, switch to the library's directory.
+```
+cp linuxdocs.sh /usr/local/bin/
+which linuxdocs.sh
+cd _path_to_boost_library_
+linuxdocs.sh
+```
+
+## MacOS
+
+There various ways to run the script. One method is to run the script from the current location, and tell it where the docs are:
+```
+./macosdocs.sh _path_to_boost_library_
+```
+Another method which might be easier is to copy the script into location in $PATH, so it can be run anywhere. Then, switch to the library's directory.
+```
+cp macosdocs.sh /usr/local/bin/
+which macosdocs.sh
+cd _path_to_boost_library_
+macosdocs.sh
+```
+
+## Windows
+
+There various ways to run the script. One method is to run the script from the current location, and tell it where the docs are:
+```
+.\windowsdocs.sh _path_to_boost_library_
+```
+Another method which might be easier is to copy the script into location in $PATH, so it can be run anywhere. Then, switch to the library's directory.
+```
+cp windowsdocs.ps1 C:\windows\system32
+where windowsdocs.ps1
+cd _path_to_boost_library_
+windowsdocs.ps1
+```
+
+&nbsp;  
+&nbsp;  
+Further discussion about a small number of issues affecting certain libraries is continued in [compatibility.md](compatibility.md)
+

--- a/build_docs/compatibility.md
+++ b/build_docs/compatibility.md
@@ -1,0 +1,30 @@
+
+## Compatibility
+
+Refer to [README.md](README.md) for general instructions.
+
+There are a few outstanding issues affecting certain libraries which either require enhancements to these scripts or updates to the Jamfile of the library so it will compile automatically. Ongoing.
+
+hof - When upgrading to newer operating systems such as Ubuntu 22.04 there are errors.
+
+leaf - boostrelease builds successfully. The default build shows an error.
+
+qvm - boostrelease builds successfully. The default build shows an error.
+
+static_string - errors. need to investigate.
+
+tools/auto_index - an error.
+
+Also some libraries should be debugged for Microsoft Windows builds: hana log parameter parameter_python
+
+## Operating Systems
+
+Ubuntu 18.04 - tested  
+Ubuntu 20.04 - tested  
+Ubuntu 22.04 - tested  
+
+MacOS 10.15 Intel CPU - tested  
+MacOS 12 Apple ARM CPU - not yet tested or debugged.
+
+Windows 2019 - tested  
+Windows 2022 - tested

--- a/build_docs/linuxdocs.sh
+++ b/build_docs/linuxdocs.sh
@@ -1,0 +1,376 @@
+#!/bin/bash
+
+# Copyright 2022 Sam Darwin
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
+set -e
+
+scriptname="linuxdocs.sh"
+
+# set defaults:
+boostrelease=""
+
+# READ IN COMMAND-LINE OPTIONS
+
+TEMP=`getopt -o t:,h::,q:: --long type:,help::,skip-boost::,skip-packages::,quick::,boostrelease:: -- "$@"`
+eval set -- "$TEMP"
+
+# extract options and their arguments into variables.
+while true ; do
+    case "$1" in
+        -h|--help)
+            helpmessage="""
+usage: $scriptname [-h] [--type TYPE] [path_to_library]
+
+Builds library documentation.
+
+optional arguments:
+  -h, --help            Show this help message and exit
+  -t, --type TYPE       The \"type\" of build. Defaults to \"main\" which installs all standard boost prerequisites.
+                        Another option is \"cppal\" which installs the prerequisites used by boostorg/json and a few other similar libraries.
+                        More \"types\" can be added in the future if your library needs a specific set of packages installed.
+                        The type is usually auto-detected and doesn't need to be specified.
+  --skip-boost   	Skip downloading boostorg/boost and building b2 if you are certain those steps have already been done.
+  --skip-packages	Skip installing all packages (pip, gem, apt, etc.) if you are certain that has already been done.
+  -q, --quick		Equivalent to setting both --skip-boost and --skip-packages. If not sure, then don't skip these steps.
+  --boostrelease	Add the target //boostrelease to the doc build. This target is used when building production releases.
+standard arguments:
+  path_to_library	Where the library is located. Defaults to current working directory.
+"""
+
+            echo ""
+	    echo "$helpmessage" ;
+	    echo ""
+            exit 0
+            ;;
+        -t|--type)
+            case "$2" in
+                "") typeoption="" ; shift 2 ;;
+                 *) typeoption=$2 ; shift 2 ;;
+            esac ;;
+	--skip-boost)
+	    skipboostoption="yes" ; shift 2 ;;
+	--skip-packages)
+	    skippackagesoption="yes" ; shift 2 ;;
+	-q|--quick)
+	    skipboostoption="yes" ; skippackagesoption="yes" ; shift 2 ;;
+	--boostrelease)
+	    boostrelease="//boostrelease" ; shift 2 ;;
+        --) shift ; break ;;
+        *) echo "Internal error!" ; exit 1 ;;
+    esac
+done
+
+# git is required. In the unlikely case it's not yet installed, moving that part of the package install process
+# here to an earlier part of the script:
+
+if [ "$skippackagesoption" != "yes" ]; then
+    sudo apt-get update
+    if ! command -v git &> /dev/null
+    then
+        sudo apt-get install -y git
+    fi
+fi
+
+if [ -n "$1" ]; then
+    echo "Library path set to $1. Changing to that directory."
+    cd $1
+else
+    workingdir=$(pwd)
+    echo "Using current working directory ${workingdir}."
+fi
+
+# DETERMINE REPOSITORY
+
+export REPONAME=$(basename -s .git `git config --get remote.origin.url` 2> /dev/null || echo "empty")
+export BOOST_SRC_FOLDER=$(git rev-parse --show-toplevel 2> /dev/null || echo "nofolder")
+
+if [ "${REPONAME}" = "empty" -o "${REPONAME}" = "release-tools" ]; then
+    echo -e "\nSet the path_to_library as the first command-line argument:\n\n$scriptname _path_to_library_\n\nOr change the working directory to that first.\n"
+    exit 1
+else
+    echo "Reponame is ${REPONAME}."
+fi
+
+# CHECK IF RUNNING IN BOOST-ROOT
+
+# this case applies to boostorg/more
+PARENTNAME=$(basename -s .git `git --git-dir ${BOOST_SRC_FOLDER}/../.git config --get remote.origin.url` 2> /dev/null || echo "not_found")
+if [ -n "${PARENTNAME}" -a "${PARENTNAME}" = "boost" ]; then
+    echo "Starting out inside boost-root."
+    BOOSTROOTLIBRARY="yes"
+    BOOSTROOTRELPATH=".."
+else
+    # most libraries
+    PARENTNAME=$(basename -s .git `git --git-dir ${BOOST_SRC_FOLDER}/../../.git config --get remote.origin.url` 2> /dev/null || echo "not_found")
+    if [ -n "${PARENTNAME}" -a "${PARENTNAME}" = "boost" ]; then
+        echo "Starting out inside boost-root."
+        BOOSTROOTLIBRARY="yes"
+        BOOSTROOTRELPATH="../.."
+    else
+        # numerics
+        PARENTNAME=$(basename -s .git `git --git-dir ${BOOST_SRC_FOLDER}/../../../.git config --get remote.origin.url` 2> /dev/null || echo "not_found")
+        if [ -n "${PARENTNAME}" -a "${PARENTNAME}" = "boost" ]; then
+            echo "Starting out inside boost-root."
+            BOOSTROOTLIBRARY="yes"
+            BOOSTROOTRELPATH="../../.."
+        else
+            echo "Not starting out inside boost-root."
+            BOOSTROOTLIBRARY="no"
+        fi
+    fi
+fi
+
+# DECIDE THE TYPE
+
+alltypes="main cppal"
+cppaltypes="json beast url http_proto socks_proto zlib"
+
+if [ -z "$typeoption" ]; then
+    if [[ " $cppaltypes " =~ .*\ $REPONAME\ .* ]]; then
+        typeoption="cppal"
+    else
+        typeoption="main"
+    fi
+fi
+
+echo "Build type is ${typeoption}."
+
+if [[ !  " $alltypes " =~ .*\ $typeoption\ .* ]]; then
+    echo "Allowed types are currently 'main' and 'cppal'. Not $typeoption. Please choose a different option. Exiting."
+    exit 1
+fi
+
+if git rev-parse --abbrev-ref HEAD | grep master ; then BOOST_BRANCH=master ; else BOOST_BRANCH=develop ; fi
+
+
+echo '==================================> INSTALL'
+
+# graphviz package added for historical reasons, might not be used.
+
+if [ "$skippackagesoption" != "yes" ]; then
+
+    # already done:
+    # sudo apt-get update
+
+    sudo apt-get install -y build-essential cmake curl default-jre-headless python3 rsync unzip wget
+
+    if [ "$typeoption" = "cppal" ]; then
+        sudo apt-get install -y bison docbook docbook-xml docbook-xsl flex libfl-dev libsaxonhe-java xsltproc
+    fi
+    if [ "$typeoption" = "main" ]; then
+        sudo apt-get install -y python3-pip ruby
+        sudo apt-get install -y bison docbook docbook-xml docbook-xsl docutils-doc docutils-common flex ghostscript graphviz libfl-dev libsaxonhe-java python3-docutils texlive texlive-latex-extra xsltproc
+	gem install public_suffix --version 4.0.7
+        sudo gem install asciidoctor --version 2.0.16
+	sudo gem install asciidoctor-pdf
+        sudo pip3 install docutils
+        # which library is using rapidxml
+        # wget -O rapidxml.zip http://sourceforge.net/projects/rapidxml/files/latest/download
+        # unzip -n -d rapidxml rapidxml.zip
+        pip3 install --user https://github.com/bfgroup/jam_pygments/archive/master.zip
+        pip3 install --user Jinja2==2.11.2
+        pip3 install --user MarkupSafe==1.1.1
+        gem install pygments.rb --version 2.1.0
+        pip3 install --user Pygments==2.2.0
+        sudo gem install rouge --version 3.26.1
+        echo "Sphinx==1.5.6" > constraints.txt
+        pip3 install --user Sphinx==1.5.6
+        pip3 install --user sphinx-boost==0.0.3
+        pip3 install --user -c constraints.txt git+https://github.com/rtfd/recommonmark@50be4978d7d91d0b8a69643c63450c8cd92d1212
+
+        # Locking the version numbers in place offers a better guarantee of a known, good build.
+	# At the same time, it creates a perpetual outstanding task, to upgrade the gem and pip versions
+        # because they are out-of-date. When upgrading everything check the Dockerfiles and the other build scripts.
+    fi
+
+    cd $BOOST_SRC_FOLDER
+    cd ..
+    mkdir -p tmp && cd tmp
+
+    if which doxygen; then
+        echo "doxygen found"
+    else
+        echo "building doxygen"
+        if [ ! -d doxygen ]; then git clone -b 'Release_1_8_15' --depth 1 https://github.com/doxygen/doxygen.git && echo "not-cached" ; else echo "cached" ; fi
+        cd doxygen
+        cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release
+        cd build
+        sudo make install
+        cd ../..
+    fi
+
+    if [ ! -f saxonhe.zip ]; then wget -O saxonhe.zip https://sourceforge.net/projects/saxon/files/Saxon-HE/9.9/SaxonHE9-9-1-4J.zip/download && echo "not-cached" ; else echo "cached" ; fi
+    unzip -d saxonhe -o saxonhe.zip
+    cd saxonhe
+    sudo rm /usr/share/java/Saxon-HE.jar || true
+    sudo cp saxon9he.jar /usr/share/java/Saxon-HE.jar
+fi
+
+cd $BOOST_SRC_FOLDER
+
+if [ "$skipboostoption" = "yes" ] ; then
+    # skip-boost was set. A reduced set of actions.
+    if [ "${BOOSTROOTLIBRARY}" = "yes" ]; then
+        cd $BOOSTROOTRELPATH
+        export BOOST_ROOT=$(pwd)
+        librarypath=$(git config --file .gitmodules --get submodule.$REPONAME.path)
+    else
+        cd ..
+        if [ ! -d boost-root ]; then
+	    echo "boost-root missing. Rerun this script without --skip-boost or --quick option."
+	    exit 1
+        else
+            cd boost-root
+            export BOOST_ROOT=$(pwd)
+            librarypath=$(git config --file .gitmodules --get submodule.$REPONAME.path)
+            rsync -av $BOOST_SRC_FOLDER/ $librarypath
+        fi
+    fi
+else
+    # skip-boost was not set. The standard flow.
+    if [ "${BOOSTROOTLIBRARY}" = "yes" ]; then
+        cd $BOOSTROOTRELPATH
+        git checkout $BOOST_BRANCH
+        git pull
+        export BOOST_ROOT=$(pwd)
+        librarypath=$(git config --file .gitmodules --get submodule.$REPONAME.path)
+    else
+        cd ..
+        if [ ! -d boost-root ]; then
+            git clone -b $BOOST_BRANCH https://github.com/boostorg/boost.git boost-root --depth 1
+            cd boost-root
+            export BOOST_ROOT=$(pwd)
+            librarypath=$(git config --file .gitmodules --get submodule.$REPONAME.path)
+            rsync -av $BOOST_SRC_FOLDER/ $librarypath
+        else
+            cd boost-root
+            git checkout $BOOST_BRANCH
+            git pull
+            export BOOST_ROOT=$(pwd)
+            librarypath=$(git config --file .gitmodules --get submodule.$REPONAME.path)
+            rsync -av $BOOST_SRC_FOLDER/ $librarypath
+        fi
+    fi
+fi
+
+if [ "$skippackagesoption" != "yes" ] ; then
+    mkdir -p build && cd build
+    if [ ! -f docbook-xsl.zip ]; then
+        wget -O docbook-xsl.zip https://sourceforge.net/projects/docbook/files/docbook-xsl/1.79.1/docbook-xsl-1.79.1.zip/download
+    fi
+    if [ ! -f docbook-xsl ]; then
+        unzip -n -d docbook-xsl docbook-xsl.zip
+    fi
+    if [ ! -f docbook-xml.zip ]; then
+        wget -O docbook-xml.zip http://www.docbook.org/xml/4.5/docbook-xml-4.5.zip
+    fi
+    if [ ! -d docbook-xml ]; then
+        unzip -n -d docbook-xml docbook-xml.zip
+    fi
+    cd ..
+fi
+
+if [ -d ${BOOST_ROOT}/build/docbook-xsl/docbook-xsl-1.79.1 ]; then
+    export DOCBOOK_XSL_DIR=${BOOST_ROOT}/build/docbook-xsl/docbook-xsl-1.79.1
+fi
+
+if [ -d ${BOOST_ROOT}/build/docbook-xml ]; then
+    export DOCBOOK_DTD_DIR=${BOOST_ROOT}/build/docbook-xml
+fi
+
+if [ "$skipboostoption" != "yes" ] ; then
+
+    git submodule update --init libs/context
+    git submodule update --init tools/boostbook
+    git submodule update --init tools/boostdep
+    git submodule update --init tools/docca
+    git submodule update --init tools/quickbook
+
+    if [ "$typeoption" = "main" ]; then
+        git submodule update --init tools/auto_index
+        git submodule update --quiet --init --recursive
+
+        # recopy the library as it might have been overwritten
+        rsync -av --delete $BOOST_SRC_FOLDER/ $librarypath
+    fi
+
+    python3 tools/boostdep/depinst/depinst.py ../tools/quickbook
+    ./bootstrap.sh
+    ./b2 headers
+
+fi
+
+# Update path
+
+if [[ ! $PATH =~ \.local/bin ]]; then
+    export PATH=~/.local/bin:$PATH
+fi
+if [[ ! $PATH =~ dist/bin ]]; then
+    export PATH=$BOOST_ROOT/dist/bin:$PATH
+fi
+
+echo '==================================> COMPILE'
+
+# exceptions:
+
+# toolslist="auto_index bcp boostbook boostdep boost_install build check_build cmake docca inspect litre quickbook"
+toolslist=("auto_index" "bcp" "boostbook" "boostdep" "boost_install" "build" "check_build" "cmake" "docca" "inspect" "litre" "quickbook")
+
+if [[ " ${toolslist[*]} " =~ " ${REPONAME} " ]] && [ "$boostrelease" = "//boostrelease" ]; then
+    echo "The boost tools do not have a //boostrelease target in their Jamfile. Run the build without --boostrelease instead."
+    exit 0
+fi
+
+if [[ "$librarypath" =~ numeric ]] && [ "$boostrelease" = "//boostrelease" ]; then
+    echo "The //boostrelease version of the numeric libraries should be run from the top level. That is, in the numeric/ directory. For this script it is a special case. TODO."
+    exit 0
+fi
+
+if [ ! -d $librarypath/doc ]; then
+    echo "doc/ folder is missing for this library. No need to compile. Exiting."
+    exit 0
+fi
+
+if [ -f $librarypath/doc/Jamfile ] || [ -f $librarypath/doc/jamfile ] || [ -f $librarypath/doc/Jamfile.v2 ] || [ -f $librarypath/doc/jamfile.v2 ] || [ -f $librarypath/doc/Jamfile.v3 ] || [ -f $librarypath/doc/jamfile.v3 ] || [ -f $librarypath/doc/Jamfile.jam ] || [ -f $librarypath/doc/jamfile.jam ] || [ -f $librarypath/doc/build.jam ] ; then
+     : # ok
+else
+    echo "doc/Jamfile (or similar) is missing for this library. No need to compile. Exiting."
+    exit 0
+fi
+
+if [ "$REPONAME" = "geometry" ]; then
+    ./b2 $librarypath/doc/src/docutils/tools/doxygen_xml2qbk
+    # adjusting PATH var instead
+    # cp dist/bin/doxygen_xml2qbk /usr/local/bin/
+    echo "Debugging for macos. which sphinx-build"
+    which sphinx-build || true
+    echo "Running ls dist/bin"
+    ls -al dist/bin || true
+fi
+
+# -------------------------------
+
+# the main compilation:
+
+if [ "$typeoption" = "main" ]; then
+    ./b2 -q -d0 --build-dir=build --distdir=build/dist tools/quickbook tools/auto_index/build
+    echo "using quickbook : build/dist/bin/quickbook ; using auto-index : build/dist/bin/auto_index ; using docutils : /usr/share/docutils ; using doxygen ; using boostbook ; using asciidoctor ; using saxonhe ;" > tools/build/src/user-config.jam
+    ./b2 -j3 $librarypath/doc${boostrelease}
+
+elif  [ "$typeoption" = "cppal" ]; then
+    echo "using doxygen ; using boostbook ; using saxonhe ;" > tools/build/src/user-config.jam
+    ./b2 $librarypath/doc${boostrelease}
+fi
+
+if [ "${BOOSTROOTLIBRARY}" = "yes" ]; then
+    echo ""
+    echo "Build completed. Check the doc/ directory."
+    echo ""
+else
+    echo ""
+    echo "Build completed. Check the results in $BOOST_SRC_FOLDER/../boost-root/$librarypath/doc"
+    echo ""
+fi

--- a/build_docs/macosdocs.sh
+++ b/build_docs/macosdocs.sh
@@ -1,0 +1,396 @@
+#!/bin/bash
+
+# Copyright 2022 Sam Darwin
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
+set -e
+
+scriptname="macosdocs.sh"
+
+# set defaults:
+boostrelease=""
+
+# git and getopt are required. If they are not installed, moving that part of the installation process
+# to an earlier part of the script:
+if ! command -v brew &> /dev/null
+then
+    echo "Installing brew. Check the instructions that are shown."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+
+if ! command -v git &> /dev/null
+then
+    echo "Installing git"
+    brew install git
+fi
+
+# check apple silicon.
+if ! command -v /usr/local/opt/gnu-getopt/bin/getopt &> /dev/null
+then
+    echo "Installing gnu-getopt"
+    brew install gnu-getopt
+fi
+export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+
+# READ IN COMMAND-LINE OPTIONS
+
+TEMP=`/usr/local/opt/gnu-getopt/bin/getopt -o t:,h::,q:: --long type:,help::,skip-boost::,skip-packages::,quick::,boostrelease:: -- "$@"`
+eval set -- "$TEMP"
+
+# extract options and their arguments into variables.
+while true ; do
+    case "$1" in
+        -h|--help)
+            helpmessage="""
+usage: $scriptname [-h] [--type TYPE] [path_to_library]
+
+Builds library documentation.
+
+optional arguments:
+  -h, --help            Show this help message and exit
+  -t, --type TYPE       The \"type\" of build. Defaults to \"main\" which installs all standard boost prerequisites.
+                        Another option is \"cppal\" which installs the prerequisites used by boostorg/json and a few other similar libraries.
+                        More \"types\" can be added in the future if your library needs a specific set of packages installed.
+                        The type is usually auto-detected and doesn't need to be specified.
+  --skip-boost          Skip downloading boostorg/boost and building b2 if you are certain those steps have already been done.
+  --skip-packages       Skip installing all packages (pip, gem, apt, etc.) if you are certain that has already been done.
+  -q, --quick           Equivalent to setting both --skip-boost and --skip-packages. If not sure, then don't skip these steps.
+  --boostrelease        Add the target //boostrelease to the doc build. This target is used when building production releases.
+standard arguments:
+  path_to_library       Where the library is located. Defaults to current working directory.
+"""
+
+            echo ""
+            echo "$helpmessage" ;
+            echo ""
+            exit 0
+            ;;
+        -t|--type)
+            case "$2" in
+                "") typeoption="" ; shift 2 ;;
+                 *) typeoption=$2 ; shift 2 ;;
+            esac ;;
+        --skip-boost)
+            skipboostoption="yes" ; shift 2 ;;
+        --skip-packages)
+            skippackagesoption="yes" ; shift 2 ;;
+        -q|--quick)
+            skipboostoption="yes" ; skippackagesoption="yes" ; shift 2 ;;
+        --boostrelease)
+            boostrelease="//boostrelease" ; shift 2 ;;
+        --) shift ; break ;;
+        *) echo "Internal error!" ; exit 1 ;;
+    esac
+done
+
+# git and getopt are required. In the unlikely case it's not yet installed, moving that part of the package install process
+# here to an earlier part of the script:
+
+if [ -n "$1" ]; then
+    echo "Library path set to $1. Changing to that directory."
+    cd $1
+else
+    workingdir=$(pwd)
+    echo "Using current working directory ${workingdir}."
+fi
+
+# DETERMINE REPOSITORY
+
+export REPONAME=$(basename -s .git `git config --get remote.origin.url` 2> /dev/null || echo "empty")
+export BOOST_SRC_FOLDER=$(git rev-parse --show-toplevel 2> /dev/null || echo "nofolder")
+
+if [ "${REPONAME}" = "empty" -o "${REPONAME}" = "release-tools" ]; then
+    echo -e "\nSet the path_to_library as the first command-line argument:\n\n$scriptname _path_to_library_\n\nOr change the working directory to that first.\n"
+    exit 1
+else
+    echo "Reponame is ${REPONAME}."
+fi
+
+# CHECK IF RUNNING IN BOOST-ROOT
+
+# this case applies to boostorg/more
+PARENTNAME=$(basename -s .git `git --git-dir ${BOOST_SRC_FOLDER}/../.git config --get remote.origin.url` 2> /dev/null || echo "not_found")
+if [ -n "${PARENTNAME}" -a "${PARENTNAME}" = "boost" ]; then
+    echo "Starting out inside boost-root."
+    BOOSTROOTLIBRARY="yes"
+    BOOSTROOTRELPATH=".."
+else
+    # most libraries
+    PARENTNAME=$(basename -s .git `git --git-dir ${BOOST_SRC_FOLDER}/../../.git config --get remote.origin.url` 2> /dev/null || echo "not_found")
+    if [ -n "${PARENTNAME}" -a "${PARENTNAME}" = "boost" ]; then
+        echo "Starting out inside boost-root."
+        BOOSTROOTLIBRARY="yes"
+        BOOSTROOTRELPATH="../.."
+    else
+        # numerics
+        PARENTNAME=$(basename -s .git `git --git-dir ${BOOST_SRC_FOLDER}/../../../.git config --get remote.origin.url` 2> /dev/null || echo "not_found")
+        if [ -n "${PARENTNAME}" -a "${PARENTNAME}" = "boost" ]; then
+            echo "Starting out inside boost-root."
+            BOOSTROOTLIBRARY="yes"
+            BOOSTROOTRELPATH="../../.."
+        else
+            echo "Not starting out inside boost-root."
+            BOOSTROOTLIBRARY="no"
+        fi
+    fi
+fi
+
+# DECIDE THE TYPE
+
+alltypes="main cppal"
+cppaltypes="json beast url http_proto socks_proto zlib"
+
+if [ -z "$typeoption" ]; then
+    if [[ " $cppaltypes " =~ .*\ $REPONAME\ .* ]]; then
+        typeoption="cppal"
+    else
+        typeoption="main"
+    fi
+fi
+
+echo "Build type is ${typeoption}."
+
+if [[ !  " $alltypes " =~ .*\ $typeoption\ .* ]]; then
+    echo "Allowed types are currently 'main' and 'cppal'. Not $typeoption. Please choose a different option. Exiting."
+    exit 1
+fi
+
+if git rev-parse --abbrev-ref HEAD | grep master ; then BOOST_BRANCH=master ; else BOOST_BRANCH=develop ; fi
+
+echo '==================================> INSTALL'
+
+# graphviz package added for historical reasons, might not be used.
+
+if [ "$skippackagesoption" != "yes" ]; then
+
+    brew install doxygen
+    brew install wget
+    brew tap adoptopenjdk/openjdk
+    brew install --cask adoptopenjdk11
+    brew install gnu-sed
+    brew install docbook
+    brew install docbook-xsl
+
+    if [ "$typeoption" = "main" ]; then
+	brew install ghostscript
+	brew install texlive
+        brew install graphviz
+	sudo gem install public_suffix --version 4.0.7
+        sudo gem install asciidoctor --version 2.0.16
+        sudo gem install asciidoctor-pdf
+        pip3 install docutils --user
+        # which library is using rapidxml
+        # wget -O rapidxml.zip http://sourceforge.net/projects/rapidxml/files/latest/download
+        # unzip -n -d rapidxml rapidxml.zip
+        pip3 install --user https://github.com/bfgroup/jam_pygments/archive/master.zip
+        pip3 install --user Jinja2==2.11.2
+        pip3 install --user MarkupSafe==1.1.1
+        sudo gem install pygments.rb --version 2.1.0
+        pip3 install --user Pygments==2.2.0
+        sudo gem install rouge --version 3.26.1
+        echo "Sphinx==1.5.6" > constraints.txt
+        pip3 install --user Sphinx==1.5.6
+        pip3 install --user sphinx-boost==0.0.3
+        pip3 install --user -c constraints.txt git+https://github.com/rtfd/recommonmark@50be4978d7d91d0b8a69643c63450c8cd92d1212
+
+        # Locking the version numbers in place offers a better guarantee of a known, good build.
+        # At the same time, it creates a perpetual outstanding task, to upgrade the gem and pip versions
+        # because they are out-of-date. When upgrading everything check the Dockerfiles and the other build scripts.
+    fi
+
+    # an alternate set of packages from https://www.boost.org/doc/libs/develop/doc/html/quickbook/install.html
+    # sudo port install libxslt docbook-xsl docbook-xml-4.2
+
+    cd $BOOST_SRC_FOLDER
+    cd ..
+    mkdir -p tmp && cd tmp
+    if [ ! -f saxonhe.zip ]; then wget -O saxonhe.zip https://sourceforge.net/projects/saxon/files/Saxon-HE/9.9/SaxonHE9-9-1-4J.zip/download; fi
+    unzip -d saxonhe -o saxonhe.zip
+    cd saxonhe
+
+    sudo rm /Library/Java/Extensions/Saxon-HE.jar || true
+    sudo cp saxon9he.jar /Library/Java/Extensions/Saxon-HE.jar
+    sudo chmod 755 /Library/Java/Extensions/Saxon-HE.jar
+
+fi
+
+# check this on apple silicon:
+export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+
+cd $BOOST_SRC_FOLDER
+
+if [ "$skipboostoption" = "yes" ] ; then
+    # skip-boost was set. A reduced set of actions.
+    if [ "${BOOSTROOTLIBRARY}" = "yes" ]; then
+        cd $BOOSTROOTRELPATH
+        export BOOST_ROOT=$(pwd)
+        librarypath=$(git config --file .gitmodules --get submodule.$REPONAME.path)
+    else
+        cd ..
+        if [ ! -d boost-root ]; then
+            echo "boost-root missing. Rerun this script without --skip-boost or --quick option."
+            exit 1
+        else
+            cd boost-root
+            export BOOST_ROOT=$(pwd)
+            librarypath=$(git config --file .gitmodules --get submodule.$REPONAME.path)
+            rsync -av $BOOST_SRC_FOLDER/ $librarypath
+        fi
+    fi
+else
+    # skip-boost was not set. The standard flow.
+    if [ "${BOOSTROOTLIBRARY}" = "yes" ]; then
+        cd $BOOSTROOTRELPATH
+        git checkout $BOOST_BRANCH
+        git pull
+        export BOOST_ROOT=$(pwd)
+        librarypath=$(git config --file .gitmodules --get submodule.$REPONAME.path)
+    else
+        cd ..
+        if [ ! -d boost-root ]; then
+            git clone -b $BOOST_BRANCH https://github.com/boostorg/boost.git boost-root --depth 1
+            cd boost-root
+            export BOOST_ROOT=$(pwd)
+            librarypath=$(git config --file .gitmodules --get submodule.$REPONAME.path)
+            rsync -av $BOOST_SRC_FOLDER/ $librarypath
+        else
+            cd boost-root
+            git checkout $BOOST_BRANCH
+            git pull
+            export BOOST_ROOT=$(pwd)
+            librarypath=$(git config --file .gitmodules --get submodule.$REPONAME.path)
+            rsync -av $BOOST_SRC_FOLDER/ $librarypath
+        fi
+    fi
+fi
+
+if [ "$skippackagesoption" != "yes" ]; then
+    mkdir -p build && cd build
+    if [ ! -f docbook-xsl.zip ]; then
+        wget -O docbook-xsl.zip https://sourceforge.net/projects/docbook/files/docbook-xsl/1.79.1/docbook-xsl-1.79.1.zip/download
+    fi
+    if [ ! -f docbook-xsl ]; then
+        unzip -n -d docbook-xsl docbook-xsl.zip
+    fi
+    if [ ! -f docbook-xml.zip ]; then
+        wget -O docbook-xml.zip http://www.docbook.org/xml/4.5/docbook-xml-4.5.zip
+    fi
+    if [ ! -d docbook-xml ]; then
+        unzip -n -d docbook-xml docbook-xml.zip
+    fi
+    cd ..
+fi
+
+if [ -d ${BOOST_ROOT}/build/docbook-xsl/docbook-xsl-1.79.1 ]; then
+    export DOCBOOK_XSL_DIR=${BOOST_ROOT}/build/docbook-xsl/docbook-xsl-1.79.1
+fi
+
+if [ -d ${BOOST_ROOT}/build/docbook-xml ]; then
+    export DOCBOOK_DTD_DIR=${BOOST_ROOT}/build/docbook-xml
+fi
+
+if [ "$skipboostoption" != "yes" ] ; then
+
+    git submodule update --init libs/context
+    git submodule update --init tools/boostbook
+    git submodule update --init tools/boostdep
+    git submodule update --init tools/docca
+    git submodule update --init tools/quickbook
+    git submodule update --init tools/build
+    sed -i 's~GLOB "/usr/share/java/saxon/"~GLOB "/Library/Java/Extensions/" "/usr/share/java/saxon/"~' tools/build/src/tools/saxonhe.jam
+
+    if [ "$typeoption" = "main" ]; then
+        git submodule update --init tools/auto_index
+        git submodule update --quiet --init --recursive
+
+        # recopy the library as it might have been overwritten
+        rsync -av --delete $BOOST_SRC_FOLDER/ $librarypath
+    fi
+
+    python3 tools/boostdep/depinst/depinst.py ../tools/quickbook
+    ./bootstrap.sh
+    ./b2 headers
+
+fi
+
+# Update path
+
+pythonbasicversion=$(python3 --version | cut -d" " -f2 | cut -d"." -f1-2)
+newpathitem=~/Library/Python/$pythonbasicversion/bin
+if [[ ! "$PATH" =~ $newpathitem ]]; then
+    export PATH=$newpathitem:$PATH
+fi
+
+if [[ ! $PATH =~ dist/bin ]]; then
+    export PATH=$BOOST_ROOT/dist/bin:$PATH
+fi
+
+echo '==================================> COMPILE'
+
+# exceptions:
+
+# toolslist="auto_index bcp boostbook boostdep boost_install build check_build cmake docca inspect litre quickbook"
+toolslist=("auto_index" "bcp" "boostbook" "boostdep" "boost_install" "build" "check_build" "cmake" "docca" "inspect" "litre" "quickbook")
+
+if [[ " ${toolslist[*]} " =~ " ${REPONAME} " ]] && [ "$boostrelease" = "//boostrelease" ]; then
+    echo "The boost tools do not have a //boostrelease target in their Jamfile. Run the build without --boostrelease instead."
+    exit 0
+fi
+
+if [[ "$librarypath" =~ numeric ]] && [ "$boostrelease" = "//boostrelease" ]; then
+    echo "The //boostrelease version of the numeric libraries should be run from the top level. That is, in the numeric/ directory. For this script it is a special case. TODO."
+    exit 0
+fi
+
+if [ ! -d $librarypath/doc ]; then
+    echo "doc/ folder is missing for this library. No need to compile. Exiting."
+    exit 0
+fi
+
+if [ -f $librarypath/doc/Jamfile ] || [ -f $librarypath/doc/jamfile ] || [ -f $librarypath/doc/Jamfile.v2 ] || [ -f $librarypath/doc/jamfile.v2 ] || [ -f $librarypath/doc/Jamfile.v3 ] || [ -f $librarypath/doc/jamfile.v3 ] || [ -f $librarypath/doc/Jamfile.jam ] || [ -f $librarypath/doc/jamfile.jam ] || [ -f $librarypath/doc/build.jam ] ; then
+     : # ok
+else
+    echo "doc/Jamfile (or similar) is missing for this library. No need to compile. Exiting."
+    exit 0
+fi
+
+if [ "$REPONAME" = "geometry" ]; then
+    set -x
+    echo "in the geometry exception. ./b2 $librarypath/doc/src/docutils/tools/doxygen_xml2qbk"
+    ./b2 $librarypath/doc/src/docutils/tools/doxygen_xml2qbk
+    echo "running pwd"
+    pwd
+    echo "Running find command"
+    find . -name '*doxygen_xml2qbk*'
+    set +x
+    echo "Debugging gil. Running find sphinx-build"
+    find ~ -name "*sphinx-build*"
+    echo "Running pip3 list"
+    pip3 list
+fi
+
+# -----------------------------------
+
+# the main compilation:
+
+if [ "$typeoption" = "main" ]; then
+    ./b2 -q -d0 --build-dir=build --distdir=build/dist tools/quickbook tools/auto_index/build
+    echo "using quickbook : build/dist/bin/quickbook ; using auto-index : build/dist/bin/auto_index ; using docutils ; using doxygen ; using boostbook ; using asciidoctor ; using saxonhe ;" > tools/build/src/user-config.jam
+    ./b2 -j3 $librarypath/doc${boostrelease}
+
+elif  [ "$typeoption" = "cppal" ]; then
+    echo "using doxygen ; using boostbook ; using saxonhe ;" > tools/build/src/user-config.jam
+    ./b2 $librarypath/doc${boostrelease}
+fi
+
+if [ "${BOOSTROOTLIBRARY}" = "yes" ]; then
+    echo ""
+    echo "Build completed. Check the doc/ directory."
+    echo ""
+else
+    echo ""
+    echo "Build completed. Check the results in $BOOST_SRC_FOLDER/../boost-root/$librarypath/doc"
+    echo ""
+fi

--- a/build_docs/windowsdocs.ps1
+++ b/build_docs/windowsdocs.ps1
@@ -1,0 +1,586 @@
+
+# Copyright 2022 Sam Darwin
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
+param (
+   [Parameter(Mandatory=$false)][alias("path")][string]$pathoption = "",
+   [Parameter(Mandatory=$false)][alias("type")][string]$typeoption = "",
+   [switch]$help = $false,
+   [switch]${skip-boost} = $false,
+   [switch]${skip-packages} = $false,
+   [switch]$quick = $false,
+   [switch]$boostrelease = $false
+)
+
+$scriptname="windowsdocs.ps1"
+
+# Set-PSDebug -Trace 1
+
+if ($help) {
+
+$helpmessage="
+usage: $scriptname [-help] [-type TYPE] [-skip-boost] [-skip-packages] [-quick] [-boostrelease] [path_to_library]
+
+Builds library documentation.
+
+optional arguments:
+  -help                 Show this help message and exit
+  -type TYPE            The `"type`" of build. Defaults to `"main`" which installs all standard boost prerequisites.
+                        Another option is `"cppal`" which installs the prerequisites used by boostorg/json and a few other similar libraries.
+                        More `"types`" can be added in the future if your library needs a specific set of packages installed.
+                        The type is usually auto-detected and doesn't need to be specified.
+  -skip-boost           Skip downloading boostorg/boost and building b2 if you are certain those steps have already been done.
+  -skip-packages        Skip installing all packages (pip, gem, apt, etc.) if you are certain that has already been done.
+  -quick                Equivalent to setting both -skip-boost and -skip-packages. If not sure, then don't skip these steps.
+  -boostrelease         Add the target //boostrelease to the doc build. This target is used when building production releases.
+
+
+standard arguments:
+  path_to_library       Where the library is located. Defaults to current working directory.
+"
+
+echo $helpmessage
+exit 0
+}
+if ($quick) { ${skip-boost} = $true ; ${skip-packages} = $true ; }
+if ($boostrelease) {
+    ${boostreleasetarget} = "//boostrelease"
+ }
+else {
+    ${boostreleasetarget} = ""
+}
+
+pushd
+
+# git is required. In the unlikely case it's not yet installed, moving that part of the package install process
+# here to an earlier part of the script:
+
+if ( -Not ${skip-packages} ) {
+    if ( -Not (Get-Command choco -errorAction SilentlyContinue) ) {
+        echo "Install chocolatey"
+        iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+    }
+
+    if ( -Not (Get-Command git -errorAction SilentlyContinue) ) {
+        echo "Install git"
+        choco install -y --no-progress git
+    }
+
+    # Make `refreshenv` available right away, by defining the $env:ChocolateyInstall
+    # variable and importing the Chocolatey profile module.
+    # Note: Using `. $PROFILE` instead *may* work, but isn't guaranteed to.
+    $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
+    Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+    refreshenv
+}
+
+if ($pathoption) {
+    echo "Library path set to $pathoption. Changing to that directory."
+    cd $pathoption
+}
+else
+{
+    $workingdir = pwd
+    echo "Using current working directory $workingdir."
+}
+
+# DETERMINE REPOSITORY
+
+$originurl=git config --get remote.origin.url
+if ($LASTEXITCODE -eq 0)  {
+    $REPONAME=[io.path]::GetFileNameWithoutExtension($originurl)
+}
+else {
+    $REPONAME="empty"
+}
+
+if (($REPONAME -eq "empty") -or ($REPONAME -eq "release-tools")) {
+    echo ""
+    echo "Set the path_to_library as the first command-line argument:"
+    echo ""
+    echo "$scriptname _path_to_library_"
+    echo ""
+    echo "Or change the working directory to that first."
+    exit 1
+}
+else {
+    echo "REPONAME is $REPONAME"
+}
+
+$BOOST_SRC_FOLDER=git rev-parse --show-toplevel
+if ( ! $LASTEXITCODE -eq 0)  {
+    $BOOST_SRC_FOLDER="nofolder"
+}
+else {
+    echo "BOOST_SRC_FOLDER is $BOOST_SRC_FOLDER"
+}
+
+$PARENTNAME=[io.path]::GetFileNameWithoutExtension($(git --git-dir $BOOST_SRC_FOLDER/../.git config --get remote.origin.url))
+if ( $PARENTNAME -eq "boost" ) {
+    echo "Starting out inside boost-root"
+    $BOOSTROOTLIBRARY="yes"
+    $BOOSTROOTRELPATH=".."
+}
+else {
+    $PARENTNAME=[io.path]::GetFileNameWithoutExtension($(git --git-dir $BOOST_SRC_FOLDER/../../.git config --get remote.origin.url))
+    if ( $PARENTNAME -eq "boost" ) {
+        echo "Starting out inside boost-root"
+        $BOOSTROOTLIBRARY="yes"
+        $BOOSTROOTRELPATH="../.."
+    }
+    else {
+        $PARENTNAME=[io.path]::GetFileNameWithoutExtension($(git --git-dir $BOOST_SRC_FOLDER/../../../.git config --get remote.origin.url))
+        if ( $PARENTNAME -eq "boost" )
+        {
+            echo "Starting out inside boost-root"
+            $BOOSTROOTLIBRARY="yes"
+            $BOOSTROOTRELPATH="../../.."
+        }
+        else {
+            echo "Not starting out inside boost-root"
+            $BOOSTROOTLIBRARY="no"
+            }
+    }
+}
+
+# DECIDE THE TYPE
+
+$alltypes="main cppal"
+$cppaltypes="json beast url http_proto socks_proto zlib"
+
+if (! $typeoption ) {
+    if ($cppaltypes.contains($REPONAME)) {
+        $typeoption="cppal"
+    }
+    else {
+        $typeoption="main"
+    }
+}
+
+echo "Build type is $typeoption"
+
+if ( ! $alltypes.contains($typeoption)) {
+    echo "Allowed types are currently 'main' and 'cppal'. Not $typeoption. Please choose a different option. Exiting."
+    exit 1
+}
+
+$REPO_BRANCH=git rev-parse --abbrev-ref HEAD
+echo "REPO_BRANCH is $REPO_BRANCH"
+
+if ( $REPO_BRANCH -eq "master" )
+{
+    $BOOST_BRANCH="master"
+}
+else
+{
+    $BOOST_BRANCH="develop"
+}
+
+echo "BOOST_BRANCH is $BOOST_BRANCH"
+
+echo '==================================> INSTALL'
+
+# graphviz package added for historical reasons, might not be used.
+
+if ( -Not ${skip-packages} ) {
+
+    if ( -Not (Get-Command choco -errorAction SilentlyContinue) ) {
+        echo "Install chocolatey"
+        iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+    }
+    choco install -y --no-progress rsync sed doxygen.install xsltproc docbook-bundle
+    if ( -Not (Get-Command java -errorAction SilentlyContinue) )
+    {
+        choco install -y --no-progress openjdk --version=17.0.1
+    }
+    if ( -Not (Get-Command make -errorAction SilentlyContinue) )
+    {
+        choco install -y --no-progress make
+    }
+    if ( -Not (Get-Command python -errorAction SilentlyContinue) )
+    {
+        choco install -y --no-progress python3
+    }
+    if ( -Not (Get-Command git -errorAction SilentlyContinue) )
+    {
+        choco install -y --no-progress git
+    }
+    if ($typeoption -eq "main") {
+    if ( -Not (Get-Command ruby -errorAction SilentlyContinue) )
+    {
+        choco install -y --no-progress ruby
+    }
+    if ( -Not (Get-Command wget -errorAction SilentlyContinue) )
+    {
+        choco install -y --no-progress wget
+    }
+    }
+    # Make `refreshenv` available right away, by defining the $env:ChocolateyInstall
+    # variable and importing the Chocolatey profile module.
+    # Note: Using `. $PROFILE` instead *may* work, but isn't guaranteed to.
+    $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
+    Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+
+    refreshenv
+
+    if ( -Not (Get-Command python3 -errorAction SilentlyContinue) )
+    {
+        # create a symbolic link since windows doesn't have python3
+        $pythoncommandpath=(Get-Command python).Path
+        $python3commandpath=(Get-Command python).Path -replace 'python.exe', 'python3.exe'
+        New-Item -ItemType SymbolicLink -Path "$python3commandpath" -Target "$pythoncommandpath"
+    }
+
+    if ($typeoption -eq "main") {
+        $ghostversion="9.56.1"
+        choco install -y --no-progress ghostscript --version $ghostversion
+        choco install -y --no-progress texlive
+        choco install -y --no-progress graphviz
+        gem install public_suffix --version 4.0.7
+        gem install asciidoctor --version 2.0.16
+        gem install asciidoctor-pdf
+        pip3 install docutils
+        wget -O rapidxml.zip http://sourceforge.net/projects/rapidxml/files/latest/download
+        unzip -n -d rapidxml rapidxml.zip
+        #
+        # pip3 had been using --user. what will happen without.
+        pip3 install https://github.com/bfgroup/jam_pygments/archive/master.zip
+        pip3 install Jinja2==2.11.2
+        pip3 install MarkupSafe==1.1.1
+        gem install pygments.rb --version 2.1.0
+        pip3 install Pygments==2.2.0
+        gem install rouge --version 3.26.1
+        echo "Sphinx==1.5.6" > constraints.txt
+        pip3 install Sphinx==1.5.6
+        pip3 install sphinx-boost==0.0.3
+        pip3 install -c constraints.txt git+https://github.com/rtfd/recommonmark@50be4978d7d91d0b8a69643c63450c8cd92d1212
+
+        refreshenv
+
+	# ghostscript fixes
+        $newpathitem="C:\Program Files\gs\gs$ghostversion\bin"
+        if( (Test-Path -Path $newpathitem) -and -Not ( $env:Path -like "*$newpathitem*"))
+        {
+               $env:Path += ";$newpathitem"
+        }
+        New-Item -ItemType SymbolicLink -Path "C:\Program Files\gs\gs9.56.1\bin\gswin32c.exe" -Target "C:\Program Files\gs\gs9.56.1\bin\gswin64c.exe"
+
+        # Locking the version numbers in place offers a better guarantee of a known, good build.
+        # At the same time, it creates a perpetual outstanding task, to upgrade the gem and pip versions
+        # because they are out-of-date. When upgrading everything check the Dockerfiles and the other build scripts.
+    }
+
+    # A bug fix, which may need to be developed further:
+    # b2 reports that the "cp" command can't be found on Windows.
+    # Let's add git's version of "cp" to the PATH.
+    $newpathitem="C:\Program Files\Git\usr\bin"
+    if( (Test-Path -Path $newpathitem) -and -Not ( $env:Path -like "*$newpathitem*"))
+    {
+           $env:Path += ";$newpathitem"
+    }
+
+    # Copy-Item "C:\Program Files\doxygen\bin\doxygen.exe" "C:\Windows\System32\doxygen.exe"
+
+    cd $BOOST_SRC_FOLDER
+    cd ..
+    if ( -Not (Test-Path -Path "tmp") )
+    {
+        mkdir tmp
+    }
+
+    cd tmp
+
+    # Install saxon
+    if ( -Not (Test-Path -Path "C:\usr\share\java\Saxon-HE.jar") )
+    {
+        $source = 'https://sourceforge.net/projects/saxon/files/Saxon-HE/9.9/SaxonHE9-9-1-4J.zip/download'
+        $destination = 'saxonhe.zip'
+        if ( Test-Path -Path $destination)
+        {
+            rm $destination
+        }
+        if ( Test-Path -Path "saxonhe")
+        {
+            rm Remove-Item saxonhe -Recurse -Force
+        }
+        Start-BitsTransfer -Source $source -Destination $destination
+        Expand-Archive .\saxonhe.zip
+        cd saxonhe
+        if ( -Not (Test-Path -Path "C:\usr\share\java") )
+        {
+            mkdir "C:\usr\share\java"
+        }
+        cp saxon9he.jar Saxon-HE.jar
+        cp Saxon-HE.jar "C:\usr\share\java\"
+    }
+
+}
+
+# re-adding the path fix from above, even if skip-packages was set.
+$newpathitem="C:\Program Files\Git\usr\bin"
+if( (Test-Path -Path $newpathitem) -and -Not ( $env:Path -like "*$newpathitem*"))
+    {
+     $env:Path += ";$newpathitem"
+    }
+
+cd $BOOST_SRC_FOLDER
+
+if ( ${skip-boost} ) {
+    # skip-boost was set. A reduced set of actions.
+    if ( $BOOSTROOTLIBRARY -eq "yes" ) {
+        cd $BOOSTROOTRELPATH
+        $Env:BOOST_ROOT=Get-Location | Foreach-Object { $_.Path }
+        echo "Env:BOOST_ROOT is $Env:BOOST_ROOT"
+        $librarypath=git config --file .gitmodules --get submodule.$REPONAME.path
+        if ( ! $LASTEXITCODE -eq 0) {
+          exit 1
+        }
+    }
+
+    else {
+        cd ..
+        if ( -Not (Test-Path -Path "boost-root") ) {
+            echo "boost-root missing. Rerun this script without the -skip-boost or -quick option."
+            exit 1
+	    }
+        else {
+            cd boost-root
+            $Env:BOOST_ROOT=Get-Location | Foreach-Object { $_.Path }
+            echo "Env:BOOST_ROOT is $Env:BOOST_ROOT"
+            $librarypath=git config --file .gitmodules --get submodule.$REPONAME.path
+            if ( ! $LASTEXITCODE -eq 0) {
+              exit 1
+            }
+
+            if (Test-Path -Path "$librarypath")
+            {
+                rmdir $librarypath -Force -Recurse
+            }
+            Copy-Item -Path $BOOST_SRC_FOLDER -Destination $librarypath -Recurse -Force
+            }
+        }
+    }
+else {
+    # skip-boost was not set. The standard flow.
+    #
+    if ( $BOOSTROOTLIBRARY -eq "yes" ) {
+        echo "updating boost-root"
+        cd $BOOSTROOTRELPATH
+        git checkout $BOOST_BRANCH
+        git pull
+        $Env:BOOST_ROOT=Get-Location | Foreach-Object { $_.Path }
+        echo "Env:BOOST_ROOT is $Env:BOOST_ROOT"
+        $librarypath=git config --file .gitmodules --get submodule.$REPONAME.path
+        if ( ! $LASTEXITCODE -eq 0) {
+          exit 1
+        }
+
+    }
+    else {
+        cd ..
+        if ( -Not (Test-Path -Path "boost-root") ) {
+            echo "cloning boost-root"
+            git clone -b $BOOST_BRANCH https://github.com/boostorg/boost.git boost-root --depth 1
+            cd boost-root
+            $Env:BOOST_ROOT=Get-Location | Foreach-Object { $_.Path }
+            echo "Env:BOOST_ROOT is $Env:BOOST_ROOT"
+            $librarypath=git config --file .gitmodules --get submodule.$REPONAME.path
+            if ( ! $LASTEXITCODE -eq 0) {
+              exit 1
+            }
+
+            if (Test-Path -Path "$librarypath")
+            {
+                rmdir $librarypath -Force -Recurse
+            }
+            Copy-Item -Path $BOOST_SRC_FOLDER -Destination $librarypath -Recurse -Force
+        }
+        else {
+            echo "updating boost-root"
+            cd boost-root
+            git checkout $BOOST_BRANCH
+            git pull
+            $Env:BOOST_ROOT=Get-Location | Foreach-Object { $_.Path }
+            echo "Env:BOOST_ROOT is $Env:BOOST_ROOT"
+            $librarypath=git config --file .gitmodules --get submodule.$REPONAME.path
+            if ( ! $LASTEXITCODE -eq 0) {
+              exit 1
+            }
+
+            if (Test-Path -Path "$librarypath")
+            {
+                rmdir $librarypath -Force -Recurse
+            }
+            Copy-Item -Path $BOOST_SRC_FOLDER -Destination $librarypath -Recurse -Force
+        }
+    }
+}
+
+if ( -Not ${skip-packages} ) {
+    mkdir build
+    cd build
+    if ( -Not (Test-Path -Path docbook-xsl.zip) ) {
+        Invoke-Webrequest -usebasicparsing -Outfile docbook-xsl.zip -uri https://github.com/docbook/xslt10-stylesheets/releases/download/release%2F1.79.2/docbook-xsl-1.79.2.zip
+    }
+    if ( -Not (Test-Path -Path docbook-xsl) ) {
+        unzip -n -d docbook-xsl docbook-xsl.zip
+    }
+    if ( -Not (Test-Path -Path docbook-xml.zip) ) {
+        wget -O docbook-xml.zip http://www.docbook.org/xml/4.5/docbook-xml-4.5.zip
+    }
+    if ( -Not (Test-Path -Path docbook-xml) ) {
+        unzip -n -d docbook-xml docbook-xml.zip
+    }
+    cd ..
+}
+
+$Folder="$Env:BOOST_ROOT/build/docbook-xsl/docbook-xsl-1.79.2"
+if (Test-Path -Path $Folder) {
+    $Env:DOCBOOK_XSL_DIR="$Env:BOOST_ROOT/build/docbook-xsl/docbook-xsl-1.79.2"
+}
+
+$Folder="$Env:BOOST_ROOT/build/docbook-xml"
+if (Test-Path -Path $Folder) {
+    $Env:DOCBOOK_DTD_DIR="$Env:BOOST_ROOT/build/docbook-xml"
+}
+
+if ( -Not ${skip-boost} ) {
+    git submodule update --init libs/context
+    git submodule update --init tools/boostbook
+    git submodule update --init tools/boostdep
+    git submodule update --init tools/docca
+    git submodule update --init tools/quickbook
+    git submodule update --init tools/build
+
+    if ($typeoption -eq "main") {
+        git submodule update --init tools/auto_index
+        git submodule update --quiet --init --recursive
+    }
+
+    # Recopy the library, as it might have been overwritten by the submodule updates that just occurred.
+    if ( -Not ($BOOSTROOTLIBRARY -eq "yes") ) {
+        if (Test-Path -Path "$librarypath")
+        {
+            rmdir $librarypath -Force -Recurse
+        }
+        Copy-Item -Path $BOOST_SRC_FOLDER -Destination $librarypath -Recurse -Force
+    }
+
+    $matcher='\.saxonhe_jar = \$(jar\[1\]) ;$'
+    $replacer='.saxonhe_jar = $(jar[1]) ;  .saxonhe_jar = \"/usr/share/java/Saxon-HE.jar\" ;'
+    sed -i "s~$matcher~$replacer~" tools/build/src/tools/saxonhe.jam
+
+    python tools/boostdep/depinst/depinst.py ../tools/quickbook
+
+    echo "Running bootstrap.bat"
+    ./bootstrap.bat
+
+    echo "Running ./b2 headers"
+    ./b2 headers
+}
+
+# Adjust PATH
+
+$newpathitem="$env:BOOST_ROOT\dist\bin"
+if( -Not ( $env:Path -like "*$newpathitem*"))
+    {
+           $env:Path = "$newpathitem;" + $env:Path
+    }
+
+$newpathitem="C:\Program Files\doxygen\bin"
+if( -Not ( $env:Path -like "*$newpathitem*"))
+    {
+           $env:Path = "$newpathitem;" + $env:Path
+    }
+echo "new env:Path is $env:Path"
+
+echo '==================================> COMPILE'
+
+# exceptions:
+
+# $toolslist="auto_index bcp boostbook boostdep boost_install build check_build cmake docca inspect litre quickbook"
+$toolslist = @("auto_index", "bcp", "boostbook", "boostdep", "boost_install", "build", "check_build", "cmake", "docca", "inspect", "litre", "quickbook")
+if ( ($toolslist.contains($REPONAME)) -and ("$boostreleasetarget" -eq "//boostrelease" )) {
+    echo "The boost tools do not have a //boostrelease target in their Jamfile. Run the build without -boostrelease instead."
+    exit 0
+}
+
+if (($librarypath -match "numeric") -and ($boostreleasetarget -eq "//boostrelease")) {
+    echo "The //boostrelease version of the numeric libraries should be run from the top level. That is, in the numeric/ directory. For this script it is a special case. TODO."
+    exit 0
+}
+
+if ( -Not (Test-Path -Path $librarypath/doc/ )) {
+    echo "doc/ folder is missing for this library. No need to compile. Exiting."
+    exit 0
+}
+
+if ( (Test-Path -Path $librarypath/doc/Jamfile) -or (Test-Path -Path $librarypath/doc/Jamfile.v2) -or (Test-Path -Path $librarypath/doc/Jamfile.v3) -or (Test-Path -Path $librarypath/doc/Jamfile.jam) -or (Test-Path -Path $librarypath/doc/build.jam)) {
+  }
+else {
+    echo "doc/Jamfile (or similar) is missing for this library. No need to compile. Exiting."
+    exit 0
+}
+
+if ("$REPONAME" -eq "geometry") {
+    echo "In geometry exception. running ./b2 $librarypath/doc/src/docutils/tools/doxygen_xml2qbk"
+    ./b2 $librarypath/doc/src/docutils/tools/doxygen_xml2qbk
+    echo "running pwd"
+    pwd
+    echo "running dir dist\bin"
+    dir dist\bin
+    echo "checking path"
+    echo $env:Path
+    # moving this to PATH var
+    # echo "running cp dist/bin/doxygen_xml2qbk C:\windows\system32"
+    # cp dist/bin/doxygen_xml2qbk.exe C:\windows\system32
+    try { (Get-Command doxygen_xml2qbk.exe).Path }
+    catch { echo "couldn't find doxygen_xml2qbk.exe" }
+}
+
+# the main compilation:
+
+if ($typeoption -eq "main") {
+
+    $asciidoctorpath=(Get-Command asciidoctor).Path -replace '\\', '/'
+    $autoindexpath="$Env:BOOST_ROOT/build/dist/bin/auto_index.exe"
+    $autoindexpath=$autoindexpath -replace '\\', '/'
+    $quickbookpath="$Env:BOOST_ROOT/build/dist/bin/quickbook.exe"
+    $quickbookpath=$quickbookpath -replace '\\', '/'
+
+    ./b2 -q -d0 --build-dir=build --distdir=build/dist tools/quickbook tools/auto_index/build
+    $content="using quickbook : `"$quickbookpath`" ; using auto-index : `"$autoindexpath`" ; using docutils ; using doxygen : `"/Program Files/doxygen/bin/doxygen.exe`" ; using boostbook ; using asciidoctor : `"$asciidoctorpath`" ; using saxonhe ;"
+    $filename="$Env:BOOST_ROOT\tools\build\src\user-config.jam"
+    [IO.File]::WriteAllLines($filename, $content)
+    ./b2 -d 2 $librarypath/doc${boostreleasetarget}
+     if ( ! $LASTEXITCODE -eq 0)  {
+         echo "doc build failed. exiting."
+         exit 1
+     }
+}
+elseif ($typeoption -eq "cppal") {
+    $content="using doxygen : `"/Program Files/doxygen/bin/doxygen.exe`" ; using boostbook ; using saxonhe ;"
+    $filename="$Env:BOOST_ROOT\tools\build\src\user-config.jam"
+    [IO.File]::WriteAllLines($filename, $content)
+    ./b2 -d 2 $librarypath/doc${boostreleasetarget}
+     if ( ! $LASTEXITCODE -eq 0)  {
+         echo "doc build failed. exiting."
+         exit 1
+     }
+}
+
+if ($BOOSTROOTLIBRARY -eq "yes") {
+    echo ""
+    echo "Build completed. Check the doc/ directory."
+    echo ""
+}
+else {
+    echo ""
+    echo "Build completed. Check the results in $BOOST_SRC_FOLDER/../boost-root/$librarypath/doc"
+    echo ""
+}
+
+popd
+


### PR DESCRIPTION
release-tools builds the entire boost release bundle. A task during that process is to compile the documentation. These new build_docs scripts are similar to that. The goal is to compile the documentation for a target library. Thus, more limited and specific. They install prerequisite apt and pip packages, and run b2. Test one target rather than the entire bundle. If someone asks "how do I build the docs for library X", the answer can be "run linuxdocs.sh".