### PR TITLE
Include CMakeLists.txt in source distribution

### DIFF
--- a/MakeBoostDistro.py
+++ b/MakeBoostDistro.py
@@ -165,8 +165,7 @@ os.makedirs(DestLibs)
 
 ## Step 1
 for f in os.listdir(SourceRoot):
-	if f != 'CMakeLists.txt':
-		CopyFile(SourceRoot, DestRoot, f)
+	CopyFile(SourceRoot, DestRoot, f)
 
 ## Step 2
 for d in BoostSpecialFolders:


### PR DESCRIPTION
When building C++ projects that require boost it is super easy to just use `FetchContent` to pull Boost sources in.

It is however super annoying that `CMakeLists.txt` is missing from the official tarball which forces users to fetch Boost from Git directly. I would be extremely grateful if this could be fixed in time for the 1.81.0 beta.

The latter introduces a number additional annoyances: it takes forever to recursively clone absolutely everything from git (fetching the tarball is much faster), CMake has a bug (or rather: missing feature) that it doesn't know how to properly cache certain things which nearly forces users into having internet connection constantl available as a hard dependency during each build, even if they have already fetched all the files etc. etc.

@pdimov