### PR TITLE
build_docs enhancement

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -77,7 +77,7 @@ jobs:
             git submodule update --init
 
             # Run at least one full build that installs everything
-            cd libs/system
+            cd libs/accumulators
             linuxdocs.sh ${{ matrix.flags }}
             cd ../..
 

--- a/build_docs/linuxdocs.sh
+++ b/build_docs/linuxdocs.sh
@@ -6,15 +6,17 @@
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
 set -e
+shopt -s extglob
 
 scriptname="linuxdocs.sh"
 
 # set defaults:
 boostrelease=""
+BOOSTROOTRELPATH=".."
 
 # READ IN COMMAND-LINE OPTIONS
 
-TEMP=`getopt -o t:,h::,q:: --long type:,help::,skip-boost::,skip-packages::,quick::,boostrelease:: -- "$@"`
+TEMP=`getopt -o t:,h::,q:: --long type:,help::,skip-boost::,skip-packages::,quick::,boostrelease::,boostrootsubdir:: -- "$@"`
 eval set -- "$TEMP"
 
 # extract options and their arguments into variables.
@@ -36,6 +38,7 @@ optional arguments:
   --skip-packages	Skip installing all packages (pip, gem, apt, etc.) if you are certain that has already been done.
   -q, --quick		Equivalent to setting both --skip-boost and --skip-packages. If not sure, then don't skip these steps.
   --boostrelease	Add the target //boostrelease to the doc build. This target is used when building production releases.
+  --boostrootsubdir	If creating a boost-root directory, instead of placing it in ../ use a subdirectory instead.
 standard arguments:
   path_to_library	Where the library is located. Defaults to current working directory.
 """
@@ -58,6 +61,8 @@ standard arguments:
 	    skipboostoption="yes" ; skippackagesoption="yes" ; shift 2 ;;
 	--boostrelease)
 	    boostrelease="//boostrelease" ; shift 2 ;;
+	--boostrootsubdir)
+		BOOSTROOTRELPATH="." ; shift 2 ;;
         --) shift ; break ;;
         *) echo "Internal error!" ; exit 1 ;;
     esac
@@ -191,7 +196,7 @@ if [ "$skippackagesoption" != "yes" ]; then
     fi
 
     cd $BOOST_SRC_FOLDER
-    cd ..
+    cd $BOOSTROOTRELPATH
     mkdir -p tmp && cd tmp
 
     if which doxygen; then
@@ -228,7 +233,7 @@ if [ "$skipboostoption" = "yes" ] ; then
         export BOOST_ROOT=$(pwd)
         librarypath=$(getlibrarypath $REPONAME)
     else
-        cd ..
+        cd $BOOSTROOTRELPATH
         if [ ! -d boost-root ]; then
 	    echo "boost-root missing. Rerun this script without --skip-boost or --quick option."
 	    exit 1
@@ -236,7 +241,8 @@ if [ "$skipboostoption" = "yes" ] ; then
             cd boost-root
             export BOOST_ROOT=$(pwd)
             librarypath=$(getlibrarypath $REPONAME)
-            rsync -av $BOOST_SRC_FOLDER/ $librarypath
+	    mkdir -p $librarypath
+	    cp -r ${BOOST_SRC_FOLDER}/!(boost-root) ${librarypath}
         fi
     fi
 else
@@ -248,21 +254,19 @@ else
         export BOOST_ROOT=$(pwd)
         librarypath=$(getlibrarypath $REPONAME)
     else
-        cd ..
+        cd $BOOSTROOTRELPATH
         if [ ! -d boost-root ]; then
             git clone -b $BOOST_BRANCH https://github.com/boostorg/boost.git boost-root --depth 1
             cd boost-root
-            export BOOST_ROOT=$(pwd)
-            librarypath=$(getlibrarypath $REPONAME)
-            rsync -av $BOOST_SRC_FOLDER/ $librarypath
-        else
-            cd boost-root
+	else
+	    cd boost-root
             git checkout $BOOST_BRANCH
             git pull
-            export BOOST_ROOT=$(pwd)
-            librarypath=$(getlibrarypath $REPONAME)
-            rsync -av $BOOST_SRC_FOLDER/ $librarypath
-        fi
+	fi
+        export BOOST_ROOT=$(pwd)
+        librarypath=$(getlibrarypath $REPONAME)
+        mkdir -p $librarypath
+        cp -r ${BOOST_SRC_FOLDER}/!(boost-root) ${librarypath}
     fi
 fi
 
@@ -304,7 +308,7 @@ if [ "$skipboostoption" != "yes" ] ; then
         git submodule update --quiet --init --recursive
 
         # recopy the library as it might have been overwritten
-        rsync -av --delete $BOOST_SRC_FOLDER/ $librarypath
+        cp -r ${BOOST_SRC_FOLDER}/!(boost-root) ${librarypath}
     fi
 
     python3 tools/boostdep/depinst/depinst.py ../tools/quickbook
@@ -347,7 +351,7 @@ fi
 if [ -f $librarypath/doc/Jamfile ] || [ -f $librarypath/doc/jamfile ] || [ -f $librarypath/doc/Jamfile.v2 ] || [ -f $librarypath/doc/jamfile.v2 ] || [ -f $librarypath/doc/Jamfile.v3 ] || [ -f $librarypath/doc/jamfile.v3 ] || [ -f $librarypath/doc/Jamfile.jam ] || [ -f $librarypath/doc/jamfile.jam ] || [ -f $librarypath/doc/build.jam ] ; then
      : # ok
 else
-    echo "doc/Jamfile (or similar) is missing for this library. No need to compile. Exiting."
+    echo "doc/Jamfile or similar is missing for this library. No need to compile. Exiting."
     exit 0
 fi
 
@@ -380,7 +384,12 @@ if [ "${BOOSTROOTLIBRARY}" = "yes" ]; then
     echo "Build completed. Check the doc/ directory."
     echo ""
 else
+    if  [ "$BOOSTROOTRELPATH" = "." ]; then
+        pathfiller="/"
+    else
+        pathfiller="/${BOOSTROOTRELPATH}/"
+    fi
     echo ""
-    echo "Build completed. Check the results in $BOOST_SRC_FOLDER/../boost-root/$librarypath/doc"
+    echo "Build completed. Check the results in ${BOOST_SRC_FOLDER}${pathfiller}boost-root/$librarypath/doc"
     echo ""
 fi

--- a/build_docs/linuxdocs.sh
+++ b/build_docs/linuxdocs.sh
@@ -7,6 +7,7 @@
 
 set -e
 shopt -s extglob
+shopt -s dotglob
 
 scriptname="linuxdocs.sh"
 
@@ -243,6 +244,7 @@ if [ "$skipboostoption" = "yes" ] ; then
             librarypath=$(getlibrarypath $REPONAME)
 	    mkdir -p $librarypath
 	    cp -r ${BOOST_SRC_FOLDER}/!(boost-root) ${librarypath}
+            # rsync -av $BOOST_SRC_FOLDER/ $librarypath
         fi
     fi
 else
@@ -267,6 +269,7 @@ else
         librarypath=$(getlibrarypath $REPONAME)
         mkdir -p $librarypath
         cp -r ${BOOST_SRC_FOLDER}/!(boost-root) ${librarypath}
+        # rsync -av $BOOST_SRC_FOLDER/ $librarypath
     fi
 fi
 
@@ -307,8 +310,11 @@ if [ "$skipboostoption" != "yes" ] ; then
         git submodule update --init tools/auto_index
         git submodule update --quiet --init --recursive
 
-        # recopy the library as it might have been overwritten
-        cp -r ${BOOST_SRC_FOLDER}/!(boost-root) ${librarypath}
+        # recopy the library if it was overwritten. This step might not be necessary.
+        if [ ! "${BOOSTROOTLIBRARY}" = "yes" ]; then
+            cp -r ${BOOST_SRC_FOLDER}/!(boost-root) ${librarypath}
+            # rsync -av --delete $BOOST_SRC_FOLDER/ $librarypath
+        fi
     fi
 
     python3 tools/boostdep/depinst/depinst.py ../tools/quickbook

--- a/build_docs/macosdocs.sh
+++ b/build_docs/macosdocs.sh
@@ -7,6 +7,7 @@
 
 set -e
 shopt -s extglob
+shopt -s dotglob
 
 scriptname="macosdocs.sh"
 
@@ -252,6 +253,7 @@ if [ "$skipboostoption" = "yes" ] ; then
             librarypath=$(getlibrarypath $REPONAME)
             mkdir -p $librarypath
             cp -r ${BOOST_SRC_FOLDER}/!(boost-root) ${librarypath}
+            # rsync -av $BOOST_SRC_FOLDER/ $librarypath
         fi
     fi
 else
@@ -276,6 +278,7 @@ else
         librarypath=$(getlibrarypath $REPONAME)
         mkdir -p $librarypath
         cp -r ${BOOST_SRC_FOLDER}/!(boost-root) ${librarypath}
+        # rsync -av $BOOST_SRC_FOLDER/ $librarypath
     fi
 fi
 
@@ -318,8 +321,11 @@ if [ "$skipboostoption" != "yes" ] ; then
         git submodule update --init tools/auto_index
         git submodule update --quiet --init --recursive
 
-        # recopy the library as it might have been overwritten
-	cp -r ${BOOST_SRC_FOLDER}/!(boost-root) ${librarypath}
+        # recopy the library if it was overwritten. This step might not be necessary.
+        if [ ! "${BOOSTROOTLIBRARY}" = "yes" ]; then
+            cp -r ${BOOST_SRC_FOLDER}/!(boost-root) ${librarypath}
+            # rsync -av --delete $BOOST_SRC_FOLDER/ $librarypath
+        fi
     fi
 
     python3 tools/boostdep/depinst/depinst.py ../tools/quickbook

--- a/build_docs/windowsdocs.ps1
+++ b/build_docs/windowsdocs.ps1
@@ -502,7 +502,7 @@ if ( -Not ${skip-boost} ) {
         git submodule update --quiet --init --recursive
     }
 
-    # Recopy the library, as it might have been overwritten by the submodule updates that just occurred.
+    # Recopy the library, if it was overwritten by the submodule updates that just occurred. Might not be necessary.
     if ( -Not ($BOOSTROOTLIBRARY -eq "yes") ) {
         if (Test-Path -Path "$librarypath")
         {

--- a/build_docs/windowsdocs.ps1
+++ b/build_docs/windowsdocs.ps1
@@ -622,10 +622,10 @@ if ($BOOSTROOTLIBRARY -eq "yes") {
 }
 else {
     if ($BOOSTROOTRELPATH -eq ".") {
-        pathfiller="/"
+        $pathfiller="/"
     }
     else {
-        pathfiller="/${BOOSTROOTRELPATH}/"
+        $pathfiller="/${BOOSTROOTRELPATH}/"
     }
     echo ""
     echo "Build completed. Check the results in ${BOOST_SRC_FOLDER}${pathfiller}boost-root/$librarypath/doc"


### PR DESCRIPTION
In the build_docs/ scripts add a flag which causes boost-root to be placed inside the library's folder instead of parallel to it.  The build process is more self-contained.   It could be used by a CI system where a build shouldn't extend beyond it's own directory.

