### PR TITLE
windowsdocs.ps1 refreshenv

### DIFF
--- a/build_docs/windowsdocs.ps1
+++ b/build_docs/windowsdocs.ps1
@@ -16,6 +16,7 @@ param (
 )
 
 $scriptname="windowsdocs.ps1"
+$originalpath=$env:PATH
 
 # Set-PSDebug -Trace 1
 
@@ -329,7 +330,8 @@ if ( -Not ${skip-packages} ) {
     $newpathitem="C:\Program Files\Git\usr\bin"
     if( (Test-Path -Path $newpathitem) -and -Not ( $env:Path -like "*$newpathitem*"))
     {
-           $env:Path += ";$newpathitem"
+        $temp_path = $env:Path.Trim(";"," ")
+        $env:Path = "${temp_path};${newpathitem}"
     }
 
     # Copy-Item "C:\Program Files\doxygen\bin\doxygen.exe" "C:\Windows\System32\doxygen.exe"
@@ -369,13 +371,20 @@ if ( -Not ${skip-packages} ) {
         cp Saxon-HE.jar "C:\usr\share\java\"
     }
 
+    # refreshenv might have deleted some path entries. Return those to the path.
+    $joinedpath="${originalpath};$env:PATH"
+    $joinedpath=$joinedpath.replace(';;',';')
+    $env:PATH = ($joinedpath -split ';' | Select-Object -Unique) -join ';'
+
 }
 
 # re-adding the path fix from above, even if skip-packages was set.
 $newpathitem="C:\Program Files\Git\usr\bin"
 if( (Test-Path -Path $newpathitem) -and -Not ( $env:Path -like "*$newpathitem*"))
     {
-     $env:Path += ";$newpathitem"
+        $temp_path = $env:Path.Trim(";"," ")
+        $env:Path = "${temp_path};${newpathitem}"
+
     }
 
 cd $BOOST_SRC_FOLDER


### PR DESCRIPTION
An interesting bug. windowsdocs.ps1 installs windows packages with chocolatey. To use the packages immediately you have to run refreshenv, which updates PATH. However, it can remove path entries as well as add path entries. If it removes the PATH to cl.exe then b2 may fail to build. So, after running refreshenv, put back the previous PATH entries.
