### PR TITLE
Update builddocs github actions CI

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -10,9 +10,11 @@ on:
   pull_request:
     paths:
       - 'build_docs/**'
+      - '.github/workflows/build_docs.yml'
   push:
     paths:
       - 'build_docs/**'
+      - '.github/workflows/build_docs.yml'
     branches:
       - master
       - develop
@@ -60,6 +62,10 @@ jobs:
         run: |
             set -x
             set -e
+
+            touch /tmp/failed.txt
+            touch /tmp/succeeded.txt
+
             apt-get update
             DEBIAN_FRONTEND="noninteractive" apt-get install -y tzdata
             apt-get install -y git sudo
@@ -103,8 +109,10 @@ jobs:
             textpart5='
                 if [[ $? != 0 ]]; then
                     echo "..failed. DOCS BUILD FAILED. LIBRARY $reponame"
+                    echo "$reponame" >> /tmp/failed.txt
                 else
                     echo "LIBRARY $reponame SUCCEEDED."
+                    echo "$reponame" >> /tmp/succeeded.txt
                 fi
             fi
             '
@@ -117,6 +125,15 @@ jobs:
 
             git submodule foreach 'runlinuxdocsquick $name'
 
+            failed=$(wc -l /tmp/failed.txt | cut -d" " -f1)
+            succeeded=$(wc -l /tmp/succeeded.txt | cut -d" " -f1)
+            echo "$failed failed, $succeeded succeeded."
+            echo ""
+            cat /tmp/failed.txt
+            if [ "$failed" != "0" ]; then
+                exit 1
+            fi
+
   macos:
     defaults:
       run:
@@ -126,10 +143,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
-            skiplist: auto_index
-          - os: macos-latest
-            # skiplist:
+          - os: macos-11
+            skiplist: auto_index contract
+          - os: macos-11
+            skiplist: contract
+            flags: "--boostrelease"
+          - os: macos-12
+            skiplist: auto_index contract
+          - os: macos-12
+            skiplist: contract
             flags: "--boostrelease"
 
     timeout-minutes: 720
@@ -143,6 +165,10 @@ jobs:
         run: |
             set -x
             set -e
+
+            touch /tmp/failed.txt
+            touch /tmp/succeeded.txt
+
             cp build_docs/macosdocs.sh /usr/local/bin/
 
             mkdir -p github/boostorg
@@ -179,9 +205,11 @@ jobs:
             textpart5='
                 if [[ $? != 0 ]]; then
                     echo "..failed. DOCS BUILD FAILED. LIBRARY $reponame"
-                    exit 1
+                    # exit 1
+                    echo "$reponame" >> /tmp/failed.txt
                 else
                     echo "LIBARY $reponame SUCCEEDED."
+                    echo "$reponame" >> /tmp/succeeded.txt
                 fi
             fi
             '
@@ -194,21 +222,30 @@ jobs:
 
             git submodule foreach 'runmacosdocsquick $name'
 
+            failed=$(wc -l /tmp/failed.txt | tr -s ' ' | cut -d' ' -f2)
+            succeeded=$(wc -l /tmp/succeeded.txt | tr -s ' ' | cut -d' ' -f2)
+            echo "$failed failed, $succeeded succeeded."
+            echo ""
+            cat /tmp/failed.txt
+            if [ "$failed" != "0" ]; then
+                exit 1
+            fi
+
   windows:
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: windows-2019
-            skiplist: auto_index hana leaf log parameter parameter_python qvm
+            # skiplist: auto_index contract hana leaf log parameter parameter_python python qvm
           - os: windows-2022
-            skiplist: auto_index hana log parameter parameter_python qvm
+            # skiplist: auto_index contract hana log parameter parameter_python python
           - os: windows-2019
             flags: "-boostrelease"
-            skiplist: hana log parameter parameter_python python
+            # skiplist: contract hana log parameter parameter_python python
           - os: windows-2022
             flags: "-boostrelease"
-            skiplist: hana log parameter parameter_python python
+            # skiplist: contract hana log parameter parameter_python python
 
     timeout-minutes: 720
     runs-on: ${{matrix.os}}
@@ -220,12 +257,16 @@ jobs:
         shell: powershell
         run: |
 
+            echo $null >> C:\succeeded.txt
+            echo $null >> C:\failed.txt
+
             function Runwindowsdocs {
                 pwd
                 windowsdocs.ps1
                 if ( ! $LASTEXITCODE -eq 0)  {
+                    echo '..failed. DOCS BUILD FAILED. LIBRARY system'
                     echo 'doc build failed in github actions. exiting.'
-                    exit 1
+                    # exit 1
                 }
             }
 
@@ -265,10 +306,12 @@ jobs:
                 if ( ! $LASTEXITCODE -eq 0)  {
                     echo "..failed. DOCS BUILD FAILED. LIBRARY $reponame"
                     echo "doc build failed in github actions. exiting."
-                    exit 1
+                    Add-Content C:\failed.txt "`n$reponame"
+                    # exit 1
                 }
                 else {
                     echo "LIBRARY $reponame SUCCEEDED."
+                    Add-Content C:\succeeded.txt "`n$reponame"
                 }
             }
             '@
@@ -294,3 +337,13 @@ jobs:
 
             # For the rest --quick
             git submodule foreach 'powershell -command C:/scripts/cifunctions.ps1 $name'
+
+            $succeeded = (Get-Content C:\succeeded.txt | Measure-Object -Line).Lines
+            $failed = (Get-Content C:\failed.txt | Measure-Object -Line).Lines
+            echo "$failed failed, $succeeded succeeded."
+
+            Get-Content C:\failed.txt
+
+            if ( $failed -ne '0' ) {
+                exit 1
+             }

--- a/build_docs/macosdocs.sh
+++ b/build_docs/macosdocs.sh
@@ -395,13 +395,14 @@ fi
 # the main compilation:
 
 if [ "$typeoption" = "main" ]; then
-    ./b2 -q -d0 --build-dir=build --distdir=build/dist tools/quickbook tools/auto_index/build
+    ./b2 -q -d0 --build-dir=build --distdir=build/dist tools/quickbook cxxstd=11
+    ./b2 -q -d0 --build-dir=build --distdir=build/dist tools/auto_index/build cxxstd=11
     echo "using quickbook : build/dist/bin/quickbook ; using auto-index : build/dist/bin/auto_index ; using docutils ; using doxygen ; using boostbook ; using asciidoctor ; using saxonhe ;" > tools/build/src/user-config.jam
     ./b2 -j3 $librarypath/doc${boostrelease}
 
 elif  [ "$typeoption" = "cppal" ]; then
     echo "using doxygen ; using boostbook ; using saxonhe ;" > tools/build/src/user-config.jam
-    ./b2 $librarypath/doc${boostrelease}
+    ./b2 $librarypath/doc${boostrelease} cxxstd=11
 fi
 
 if [ "${BOOSTROOTLIBRARY}" = "yes" ]; then


### PR DESCRIPTION
This update doesn't affect releases.  

- Modify Github Actions CI file, improve data collection of the "build_docs" scripts, which are building individual libraries.
- Add cxxstd for MacOS, because newer versions of boost are dropping cxxstd 03 support.

