### PR TITLE
Sync to S3

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -9,3 +9,4 @@ While there should preferably be only one official docker image to build the boo
 | docker/python2/bionic/Dockerfile | Python2 on Bionic | cppalliance/boost_superproject_build:build-deps-4 | 2021-10-20 was used |
 | docker/python3/bionic/Dockerfile | Python3 on Bionic | cppalliance/boost_superproject_build:python3-build2 | late 2021 through most of 2022 this was in production |
 | docker/python3/focal/Dockerfile | Python3 on Focal | cppalliance/boost_superproject_build:20.04-v1 | 2023-01 Updates most gem and pip packages |
+| docker/python3/focal/Dockerfile | Python3 on Focal | cppalliance/boost_superproject_build:20.04-v2 | 2023-09 Install rclone and aws cli |

--- a/docker/python3/focal/Dockerfile
+++ b/docker/python3/focal/Dockerfile
@@ -37,10 +37,13 @@ RUN apt-get update \
         apt-transport-https \
         ca-certificates \
         vim \
+        sudo \
         python \
     && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
     && dpkg-reconfigure --frontend=noninteractive locales \
     && update-locale LANG=en_US.UTF-8 \
+    && mkdir /tmp/aws_cli_install && cd /tmp/aws_cli_install && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && cd /root && rm -rf /tmp/aws_cli_install \
+    && mkdir /tmp/rclone_install && cd /tmp/rclone_install && wget https://downloads.rclone.org/v1.63.1/rclone-v1.63.1-linux-amd64.deb && dpkg -i rclone-v1.63.1-linux-amd64.deb && cd /root && rm -rf /tmp/rclone_install \
     && curl -s -S --retry 10 -L -o gh_2.16.1_linux_amd64.deb https://github.com/cli/cli/releases/download/v2.16.1/gh_2.16.1_linux_amd64.deb \
     && dpkg -i gh_2.16.1_linux_amd64.deb \
     && git clone -b 'Release_1_9_5' --depth 1 https://github.com/doxygen/doxygen.git \

--- a/docker/python3/focal/buildrelease.sh
+++ b/docker/python3/focal/buildrelease.sh
@@ -4,7 +4,7 @@
 
 cd $HOME
 
-boostbranch=master
+boostbranch=develop
 if [ ! -d project ]; then
     git clone https://github.com/boostorg/boost project
     cd project


### PR DESCRIPTION
Adds a new function `upload_to_s3` in ci_boost_release.py.  For a limited and specific purpose. Documentation is hosted on the boost.org website at these URLs:

https://www.boost.org/doc/libs/develop/
https://www.boost.org/doc/libs/master/

Those are folders "develop" and "master" on the webserver.   In the new website, those sets of files should also be uploaded somewhere, and hosted by the website.  `upload_to_s3` does that.  The files will be in extracted format, not a zipped archive.  