### PR TITLE
Support Antora documentation

### DIFF
--- a/docker/python3/focal/Dockerfile
+++ b/docker/python3/focal/Dockerfile
@@ -79,6 +79,18 @@ RUN apt-get update \
     && pip3 install --user six==1.14.0 \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean -y
+
+ENV NODE_VERSION=18.18.1
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+ENV NVM_DIR=/root/.nvm
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+RUN node --version
+RUN npm --version
+RUN npm install -g gulp-cli
+
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8


### PR DESCRIPTION
This commit adds support for libraries with Antora documentation. In this workflow, each library can be an Antora component in an Antora master project hosted in another repository (https://github.com/cppalliance/site-docs) which also includes extra components with the user guide, contributor guide, and a component about the review process. At a later step, the antora documentation is merged with the existing in-source documentation generated with other tools.