### PR TITLE
Patch Antora directories only

### DIFF
--- a/ci_boost_release.py
+++ b/ci_boost_release.py
@@ -700,9 +700,15 @@ class script(script_common):
         release_lib_docs = os.path.join(
             self.releases_dir, self.boost_release_name, "libs"
         )
-        shutil.copytree(
-            antora_lib_docs, release_lib_docs, symlinks=False, dirs_exist_ok=True
-        )
+        for d in os.listdir(antora_lib_docs):
+            if not os.path.isdir(os.path.join(antora_lib_docs, d)):
+                continue
+            shutil.copytree(
+                os.path.join(antora_lib_docs, d),
+                os.path.join(release_lib_docs, d),
+                symlinks=False,
+                dirs_exist_ok=True,
+            )
 
         packages = []
         archive_files = []


### PR DESCRIPTION
Changes the release script to only patch `libs` with directories from the Antora documentation. 

This means `libs` won't be patched with files from the Antora build dir, such as `404.html`, `robots.txt`, and `sitemap.xml`, as these are the responsibility of the boost website. Antora also used to generate and need a `search-index.js` file but that's been already removed in https://github.com/cppalliance/site-docs/commit/fc1bd3962203f673877ea08d3b010a6034afbbf6.

The only problem left is `_` in `libs`. We're discussing a solution to that.

Related to #57.