### PR TITLE
publish_release.py: inform CDN origins about new archive files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.env


### PR DESCRIPTION
The boost downloads are hosted on an additional site `archives.boost.io` which is a Fastly CDN.   `brorigin1.cpp.al` and `brorigin2.cpp.al` are the origin servers.  After running `publish-release.py` upload a list of new files to "/tmp/boostarchivesinfo/filelist.txt".  This informs the origin servers that they should download the new files from jfrog, or wherever they are available.  The files would be downloaded anyway, but it's on a 1-day schedule, so the purpose of this feature is to speed up the process.