### PR TITLE
Set 7z threads to 2

### DIFF
--- a/ci_boost_release.py
+++ b/ci_boost_release.py
@@ -768,6 +768,7 @@ class script(script_common):
                     "a",
                     "-bd",
                     "-mx=7",
+                    "-mmt2",
                     "-ms=on",
                     "-x!" + self.boost_release_name + "/ci_boost_common.py",
                     "-x!" + self.boost_release_name + "/ci_boost_release.py",


### PR DESCRIPTION
When switching to ubuntu 24.04, 7z started crashing 

```
*** buffer overflow detected ***: terminated
```

This pull request restricts the number of threads.

```
-mmt2
```



