### PR TITLE
docker: jenkins user for CI

### DIFF
--- a/docker/python3/noble/Dockerfile
+++ b/docker/python3/noble/Dockerfile
@@ -108,6 +108,10 @@ RUN npm install -g @mermaid-js/mermaid-cli@10.5.1
 # RUN wget http://launchpadlibrarian.net/740831076/zip_3.0-14_amd64.deb && sudo dpkg -i zip_3.0-14_amd64.deb && rm zip_3.0-14_amd64.deb
 # Temporary zip fix 2:
 COPY zip /usr/bin/zip
+# For other CI jobs:
+RUN groupadd -g 150 jenkins
+RUN useradd jenkins -u 150 -g 150 -m -s /bin/bash
+RUN echo "ALL ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/all
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8

--- a/docker/python3/noble/buildimage.sh
+++ b/docker/python3/noble/buildimage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # update the image name as necessary.
-imagename="cppalliance/boost_superproject_build:24.04-v1"
+imagename="cppalliance/boost_superproject_build:24.04-v2"
 docker build --progress=plain -t $imagename . 2>&1 | tee /tmp/output.txt


### PR DESCRIPTION
Usually the boost build runs as `root`.  For external CI jobs that are testing documentation builds (not in circleci), it's helpful to allow a regular user (named jenkins) to sudo and install packages in a container.    This does not affect the usual workflow which continues to use `root`.