### PR TITLE
update release script to convert submodules to repositories

### DIFF
--- a/ci_boost_release.py
+++ b/ci_boost_release.py
@@ -559,6 +559,33 @@ class script(script_common):
             "using saxonhe ;",
         )
 
+        # Before we build the full docs, make sure each repo opting into Antora
+        # doc generation is a git repository, and not a submodule
+        # In theory, this is only a temporary workaround and Antora will someday
+        # be able to work with submodules.
+        antora_libraries = []
+
+        os.chdir(self.root_dir)
+        for directoryname in glob.iglob("libs/*", recursive=False):
+            if (
+                os.path.isdir(directoryname)
+                and os.path.isfile(os.path.join(directoryname, "doc", "antora_docs.sh"))
+            ):  # filter dirs
+                antora_libraries.append(directoryname)
+
+        for antora_lib in antora_libraries:
+            os.chdir(antora_lib)
+            # for a submodule .git is a file pointing to the gitdir
+            if (not os.path.isfile(".git")):
+                print("skipping library: %s, already a git repository" % antora_lib)
+                continue
+
+            utils.check_call("rm", ".git")
+            utils.check_call("git", "init")
+            utils.check_call("git", "add", "doc")
+            utils.check_call("git", "commit", "-m", "\"dummy antora commit\"")
+
+
         # Build the full docs, and all the submodule docs.
         os.chdir(os.path.join(self.root_dir, "doc"))
 

--- a/ci_boost_release.py
+++ b/ci_boost_release.py
@@ -567,24 +567,22 @@ class script(script_common):
 
         os.chdir(self.root_dir)
         for directoryname in glob.iglob("libs/*", recursive=False):
-            if (
-                os.path.isdir(directoryname)
-                and os.path.isfile(os.path.join(directoryname, "doc", "antora_docs.sh"))
+            if os.path.isdir(directoryname) and os.path.isfile(
+                os.path.join(directoryname, "doc", "antora_docs.sh")
             ):  # filter dirs
                 antora_libraries.append(directoryname)
 
         for antora_lib in antora_libraries:
             os.chdir(antora_lib)
             # for a submodule .git is a file pointing to the gitdir
-            if (not os.path.isfile(".git")):
+            if not os.path.isfile(".git"):
                 print("skipping library: %s, already a git repository" % antora_lib)
                 continue
 
             utils.check_call("rm", ".git")
             utils.check_call("git", "init")
             utils.check_call("git", "add", "doc")
-            utils.check_call("git", "commit", "-m", "\"dummy antora commit\"")
-
+            utils.check_call("git", "commit", "-m", '"dummy antora commit"')
 
         # Build the full docs, and all the submodule docs.
         os.chdir(os.path.join(self.root_dir, "doc"))


### PR DESCRIPTION
Antora documentation builds require that a directory is a git repository. To facilitate this when building the docs during the release process, we introduce a convention of `doc/antora_docs.sh` which the release script uses to convert the git submodule in `/root/project/libs` to a proper git repository that can work with Antora. From there, it's up to each library's `doc/Jamfile.v2` to generate its own docs properly.