### PR TITLE
ci_boost_release: Add highlight.js for Asciidoctor documentation

### DIFF
--- a/ci_boost_release.py
+++ b/ci_boost_release.py
@@ -555,7 +555,7 @@ class script(script_common):
                 os.path.join(self.build_dir, "docbook-xsl", "docbook-xsl-1.79.1"),
                 os.path.join(self.build_dir, "docbook-xml"),
             ),
-            "using asciidoctor ;",
+            "using asciidoctor : : asciidoctor-attribute=source-highlighter=highlight.js ;",
             "using saxonhe ;",
         )
 

--- a/docker/python3/noble/v4/README.md
+++ b/docker/python3/noble/v4/README.md
@@ -1,0 +1,10 @@
+## Noble v4 Docker Image
+
+This Docker image includes all dependencies needed for building Boost documentation, including:
+
+- highlight.js for Asciidoctor source code highlighting
+- All standard documentation building tools
+
+The highlight.js integration allows for better code highlighting in Asciidoctor documentation pages, replacing the default Rouge highlighter.
+
+Refer to the README.md in the docker/ folder.


### PR DESCRIPTION
- Update ci_boost_release.py to configure Asciidoctor to use highlight.js for source code highlighting\n- Document the use of highlight.js in the v4 Dockerfile README\n\nThis addresses the first part of boostorg/boostlook#67 by ensuring the build system is properly configured to use highlight.js with Asciidoctor documentation.