### PR TITLE
build_docs: mrdocs, clang compiler support

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -289,6 +289,7 @@ jobs:
             flags: "-boostrelease"
             skiplist: contract hana log parameter parameter_python python url
           - os: windows-2022
+            lint: yes
             flags: "-boostrelease"
             skiplist: contract hana log parameter parameter_python python url
 
@@ -297,7 +298,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+      - name: Install ScriptAnalyzer pre-reqs
+        if: ${{ matrix.lint == 'yes' }}
+        run: |
+          # is anything needed
+          $true
+      - name: ScriptAnalyzer
+        if: ${{ matrix.lint == 'yes' }}
+        run: |
+          Invoke-ScriptAnalyzer -EnableExit build_docs/windowsdocs.ps1
       - name: docs
         shell: powershell
         run: |

--- a/build_docs/other/windows-VS-2022-clang.ps1
+++ b/build_docs/other/windows-VS-2022-clang.ps1
@@ -3,7 +3,8 @@ iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.p
 
 echo "You may need to close and re-open your shell window."
 
-choco install -y visualstudio2022buildtools --parameters  \"--add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.CMake.Project\"
+choco feature disable --name='ignoreInvalidOptionsSwitches'
+choco install -y visualstudio2022buildtools --parameters  "--add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.CMake.Project"
 # choco install -y 7zip.install --version 22.1
 # choco install -y cmake.install --installargs '\"ADD_CMAKE_TO_PATH=System\"' --version 3.27.9
 # choco install -y curl --version 8.0.1
@@ -23,4 +24,5 @@ choco install -y vcredist2017 --version 14.16.27033
 choco install -y windows-sdk-10.1 --version 10.1.18362.1
 # choco install -y winscp --version 5.21.8
 # choco install -y winscp.install --version 5.21.8
-choco upgrade visualstudio2022-workload-vctools --package-parameters "--add Microsoft.VisualStudio.Component.VC.14.34.17.4.x86.x64" "--add Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64" "--add Microsoft.VisualStudio.Component.VC.v141.x86.x64" "--add Microsoft.VisualStudio.Component.VC.140" -y 
+choco upgrade -y visualstudio2022-workload-vctools --package-parameters "--add Microsoft.VisualStudio.Component.VC.14.34.17.4.x86.x64 --add Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.140"
+

--- a/build_docs/windowsdocs.ps1
+++ b/build_docs/windowsdocs.ps1
@@ -22,7 +22,7 @@ $nvm_install_version="1.1.11"
 $node_version="20.17.0"
 $node_version_basic="20"
 
-Set-PSDebug -Trace 1
+# Set-PSDebug -Trace 1
 
 if ($help) {
 
@@ -49,6 +49,8 @@ standard arguments:
 "
 
 Write-Output $helpmessage
+# echo $helpmessage
+
 exit 0
 }
 if ($quick) { ${skip-boost} = $true ; ${skip-packages} = $true ; }
@@ -79,7 +81,7 @@ function refenv {
 
     # refreshenv might delete path entries. Return those to the path.
     $originalpath=$env:PATH
-    refreshenv
+    Update-SessionEnvironment
     $joinedpath="${originalpath};$env:PATH"
     $joinedpath=$joinedpath.replace(';;',';')
     $env:PATH = ($joinedpath -split ';' | Select-Object -Unique) -join ';'
@@ -128,6 +130,61 @@ function DownloadWithRetry([string] $url, [string] $downloadLocation, [int] $ret
                 throw $exception
             }
         }
+    }
+}
+
+function LocateCLCompiler([string] $docsFolder) {
+
+    # MrDocs requires a C++ compiler. Possibly other software will require a C++ compiler.
+    $startdir = Get-Location | Foreach-Object { $_.Path }
+    Set-Location $docsFolder
+    # Determine if a C++ compiler is needed.
+    $clang_required="no"
+    $ResultList = (Get-ChildItem -Exclude test*,.test*,windowsdocs.ps1 | Select-String -quiet "mrdocs")
+    foreach ($result in $ResultList){
+        if ($result -eq "True") {
+              # Write-Output $result
+              $clang_required="yes"
+        }
+    }
+    # Now we know if $clang_required
+    Set-Location $startdir
+
+    # Determine if a C++ compiler is available.
+    get-command cl.exe *>$null
+    if ( $? -eq "True" ) {
+            Write-Output "Found cl.exe"
+            $cl_available="yes"
+    }
+    else {
+            Write-Output "cl.exe not found"
+            $cl_available="no"
+    }
+
+    if ($clang_required -eq "no" -Or $cl_available -eq "yes") {
+        # Success
+        return
+    }
+    else {
+    # Include other Launch-VsDevShell.ps1 locations in this list:
+    $cl_command_attempts = @('C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\Common7\\Tools\\Launch-VsDevShell.ps1',
+	                         'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1')
+    foreach ($cl_command_attempt in $cl_command_attempts) {
+        & $cl_command_attempt -arch amd64
+        get-command cl.exe *>$null
+        if ( $? -eq "True" ) {
+            Write-Output "Found cl.exe"
+            $cl_available="yes"
+            return
+        }
+        else {
+            Write-Output "cl.exe not found"
+            $cl_available="no"
+        }
+    }
+    Write-Output "MrDocs requires a C++ compiler, however one couldn't be found. There is a script here in build_docs/other/windows-VS-2022-clang.ps1 that may be used to install Visual Studio. After that, run this script again. If you believe the compiler cl.exe is available, feel free to examine this function LocateCLCompiler() and submit bug fixes."
+    Write-Output "Exiting."
+    exit 1
     }
 }
 
@@ -695,6 +752,10 @@ if ("$REPONAME" -eq "geometry") {
     try { (Get-Command doxygen_xml2qbk.exe).Path }
     catch { Write-Output "couldn't find doxygen_xml2qbk.exe" }
 }
+
+# a preflight compiler check
+
+LocateCLCompiler("$librarypath/doc")
 
 # the main compilation:
 


### PR DESCRIPTION
Previous versions of build_docs did not install or require a C++ compiler.

Now it appears that [MrDocs](https://github.com/cppalliance/mrdocs) expects a local C++ compiler to be available.

Typically that will already be the case.   However, rather than forcibly install clang on every system (especially Windows), the script will attempt to detect if MrDocs is used, and if Visual Studio is already available.   In the critical case (mainly on Windows), prompt the user to go install Visual Studio before proceeding.  