### PR TITLE
publish_release.py modify webhook

### DIFF
--- a/publish_release.py
+++ b/publish_release.py
@@ -411,7 +411,9 @@ def import_new_releases():
         LOGIN = f"{BASE_ADMIN}login/"
         if options.beta == None and options.rc == None:
             # Standard releases
-            NEW_RELEASE = f"{BASE_ADMIN}versions/version/release_tasks/"
+            NEW_RELEASE = f"{BASE_ADMIN}versions/version/new_versions/"
+            # "release_tasks" were more extensive. May be deprecated.
+            # NEW_RELEASE = f"{BASE_ADMIN}versions/version/release_tasks/"
         elif options.rc == None:
             # Betas
             NEW_RELEASE = f"{BASE_ADMIN}versions/version/new_versions/"


### PR DESCRIPTION
The webhook "new_versions" -> "Import New Releases" has always been the standard method.  

The webhook "release_tasks" -> "Do It All" includes the release report. However the release report has been migrated.  It's questionable that needs to be done.  Return to "new_versions" for the moment.  

