### PR TITLE
Clean up node_modules

### DIFF
--- a/ci_boost_release.py
+++ b/ci_boost_release.py
@@ -534,6 +534,13 @@ class script(script_common):
             utils.check_call("git", "init")
             utils.check_call("git", "add", "doc")
             utils.check_call("git", "commit", "-m", '"dummy antora commit"')
+            utils.check_call(
+                "git",
+                "remote",
+                "add",
+                "origin",
+                f"https://github.com/boostorg/{antora_lib}",
+            )
 
         # Build the full docs, and all the submodule docs.
         os.chdir(os.path.join(self.root_dir, "doc"))
@@ -639,7 +646,14 @@ class script(script_common):
             )
         )
         utils.check_call(
-            "git", "submodule", "--quiet", "foreach", "rm", "-fr", "doc/bin"
+            "git",
+            "submodule",
+            "--quiet",
+            "foreach",
+            "rm",
+            "-fr",
+            "doc/bin",
+            "doc/node_modules",
         )
 
         # Make the real distribution tree from the base tree.


### PR DESCRIPTION
This PR does two things:

- Remove "doc/node_modules" from libraries after the build. Since that directory adds extra MBs, and isn't needed.  

- Configure a "git remote" on libraries that are using antora, and where temporarily there is a fake git configuration to bypass an antora limitation.